### PR TITLE
ATM-174 VOTING BUG FIX: Be able to edit a voting event when it's on progress

### DIFF
--- a/attendance-manager/.gitignore
+++ b/attendance-manager/.gitignore
@@ -45,4 +45,5 @@ next-env.d.ts
 # Supabase local dev files
 supabase/.branches/
 supabase/.local/
-.supabase/supabase/.temp/
+supabase/.temp/
+.supabase/

--- a/attendance-manager/src/app/api/voting-record/[votingRecordId]/route.ts
+++ b/attendance-manager/src/app/api/voting-record/[votingRecordId]/route.ts
@@ -1,0 +1,45 @@
+import { VotingRecordController } from '@/voting-record/voting-record.controller';
+
+/**
+ * @swagger
+ * /api/voting-record/{votingRecordId}:
+ *   patch:
+ *     summary: Updates an existing voting record (e.g. admin corrects a vote while the event is ongoing).
+ *     parameters:
+ *       - in: path
+ *         name: votingRecordId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - result
+ *             properties:
+ *               result:
+ *                 type: string
+ *               updatedBy:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Updated voting record.
+ *       400:
+ *         description: Invalid body, completed event, or invalid result.
+ *       403:
+ *         description: Secret ballot events cannot have per-record edits.
+ *       404:
+ *         description: Voting record not found.
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ votingRecordId: string }> },
+) {
+  const { votingRecordId } = await params;
+  return VotingRecordController.updateVotingRecord(request, {
+    votingRecordId,
+  });
+}

--- a/attendance-manager/src/components/layout/Layout.tsx
+++ b/attendance-manager/src/components/layout/Layout.tsx
@@ -16,7 +16,7 @@ const Layout: React.FC = () => {
   const [activeTab, setActiveTab] = useState<
     'dashboard' | 'meetings' | 'voting' | 'attendance' | 'profile'
   >('dashboard');
-  const { user } = useAuth();
+  const { user, isLoading } = useAuth();
   const isAdmin = user?.role === 'EBOARD';
   const { activeEvent } = useActiveVotingEvent();
   const [canVoteInActiveEvent, setCanVoteInActiveEvent] = useState(false);
@@ -121,6 +121,14 @@ const Layout: React.FC = () => {
         return <Dashboard />;
     }
   };
+
+  if (isLoading) {
+    return (
+      <div className='min-h-screen flex items-center justify-center bg-gray-50'>
+        <p className='text-sm text-gray-600'>Loading…</p>
+      </div>
+    );
+  }
 
   if (!user) {
     return <LoginPage />;

--- a/attendance-manager/src/components/voting/EditVotingRecordsModal.tsx
+++ b/attendance-manager/src/components/voting/EditVotingRecordsModal.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { VotingEventApiData, VotingRecordApiData } from '@/types';
+import { useAuth } from '@/contexts/AuthContext';
+import { VOTING_TYPES, YES_NO_OPTIONS } from '@/utils/consts';
+import { formatResultLabel } from './votingDisplayUtils';
+
+interface EditVotingRecordsModalProps {
+  votingEventId: string;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+function choiceOptionsForEvent(event: VotingEventApiData): string[] {
+  if (event.voteType === VOTING_TYPES.ROLL_CALL.key) {
+    return Object.values(YES_NO_OPTIONS);
+  }
+  if (event.options && event.options.length > 0) {
+    return event.options;
+  }
+  return ['YES', 'NO', 'ABSTAIN'];
+}
+
+const EditVotingRecordsModal: React.FC<EditVotingRecordsModalProps> = ({
+  votingEventId,
+  onClose,
+  onSaved,
+}) => {
+  const { user } = useAuth();
+  const [event, setEvent] = useState<VotingEventApiData | null>(null);
+  const [rows, setRows] = useState<VotingRecordApiData[]>([]);
+  const [initialResults, setInitialResults] = useState<Record<string, string>>(
+    {},
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [savingId, setSavingId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/voting-event/${votingEventId}`);
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Failed to load (${res.status})`);
+      }
+      const data = await res.json();
+      setEvent(data);
+      const list = (data.votingRecords || []).filter(
+        (r: VotingRecordApiData) => !r.deletedAt,
+      );
+      setRows(list);
+      const snap: Record<string, string> = {};
+      list.forEach((r: VotingRecordApiData) => {
+        snap[r.votingRecordId] = r.result;
+      });
+      setInitialResults(snap);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load voting event');
+    } finally {
+      setLoading(false);
+    }
+  }, [votingEventId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const setRowResult = (votingRecordId: string, result: string) => {
+    setRows((prev) =>
+      prev.map((r) =>
+        r.votingRecordId === votingRecordId ? { ...r, result } : r,
+      ),
+    );
+  };
+
+  const saveRow = async (row: VotingRecordApiData) => {
+    const original = initialResults[row.votingRecordId];
+    if (row.result === original) return;
+
+    setSavingId(row.votingRecordId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/voting-record/${row.votingRecordId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          result: row.result,
+          ...(user?.id ? { updatedBy: user.id } : {}),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || `Update failed (${res.status})`);
+      }
+      setInitialResults((prev) => ({
+        ...prev,
+        [row.votingRecordId]: row.result,
+      }));
+      onSaved();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update');
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const displayName = (r: VotingRecordApiData) => {
+    if (r.user?.firstName || r.user?.lastName) {
+      return `${r.user.firstName ?? ''} ${r.user.lastName ?? ''}`.trim();
+    }
+    return `User ${r.userId.slice(0, 8)}…`;
+  };
+
+  const choices = event ? choiceOptionsForEvent(event) : [];
+
+  return (
+    <div className='fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50'>
+      <div className='mx-4 max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl bg-white p-6'>
+        <h3 className='mb-2 text-lg font-semibold text-gray-900'>
+          Edit Voting Records
+        </h3>
+        <p className='mb-4 text-sm text-gray-600'>{event?.name ?? '…'}</p>
+
+        {loading && (
+          <p className='text-sm text-gray-500'>Loading records…</p>
+        )}
+
+        {!loading && error && (
+          <p className='mb-4 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-sm text-red-600'>
+            {error}
+          </p>
+        )}
+
+        {!loading && event && rows.length === 0 && (
+          <p className='text-sm text-gray-500'>No votes recorded yet.</p>
+        )}
+
+        {!loading && rows.length > 0 && event && (
+          <div className='max-h-96 overflow-y-auto rounded-lg border border-gray-300'>
+            <table className='w-full text-sm'>
+              <thead>
+                <tr className='border-b border-gray-200 bg-gray-50'>
+                  <th className='px-4 py-2 text-left font-medium text-gray-900'>
+                    Voter
+                  </th>
+                  <th className='px-4 py-2 text-left font-medium text-gray-900'>
+                    Vote
+                  </th>
+                  <th className='px-4 py-2 text-right font-medium text-gray-900'>
+                    Action
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => {
+                  const dirty = row.result !== initialResults[row.votingRecordId];
+                  const optionList = choices.includes(row.result)
+                    ? choices
+                    : [...choices, row.result];
+                  return (
+                    <tr
+                      key={row.votingRecordId}
+                      className='border-b border-gray-100 transition-colors last:border-0 hover:bg-gray-50'
+                    >
+                      <td className='px-4 py-3 align-middle text-gray-900'>
+                        {displayName(row)}
+                      </td>
+                      <td className='px-4 py-3 align-middle'>
+                        <select
+                          value={row.result}
+                          onChange={(e) =>
+                            setRowResult(row.votingRecordId, e.target.value)
+                          }
+                          className='w-full max-w-xs rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-[#C8102E] focus:outline-none focus:ring-2 focus:ring-[#C8102E] focus:ring-offset-0'
+                          disabled={savingId === row.votingRecordId}
+                        >
+                          {optionList.map((opt) => (
+                            <option key={opt} value={opt}>
+                              {formatResultLabel(opt)}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className='px-4 py-3 text-right align-middle'>
+                        <button
+                          type='button'
+                          disabled={
+                            !dirty || savingId === row.votingRecordId
+                          }
+                          onClick={() => saveRow(row)}
+                          className='rounded-lg bg-[#C8102E] px-4 py-2 text-sm font-semibold text-white hover:bg-[#A8102E] disabled:cursor-not-allowed disabled:opacity-60'
+                        >
+                          {savingId === row.votingRecordId
+                            ? 'Saving…'
+                            : 'Update'}
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <div className='mt-6 flex space-x-3 border-t border-gray-200 pt-6'>
+          <button
+            type='button'
+            onClick={onClose}
+            className='flex-1 rounded-lg border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50'
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EditVotingRecordsModal;

--- a/attendance-manager/src/components/voting/EditVotingRecordsModal.tsx
+++ b/attendance-manager/src/components/voting/EditVotingRecordsModal.tsx
@@ -124,9 +124,7 @@ const EditVotingRecordsModal: React.FC<EditVotingRecordsModalProps> = ({
         </h3>
         <p className='mb-4 text-sm text-gray-600'>{event?.name ?? '…'}</p>
 
-        {loading && (
-          <p className='text-sm text-gray-500'>Loading records…</p>
-        )}
+        {loading && <p className='text-sm text-gray-500'>Loading records…</p>}
 
         {!loading && error && (
           <p className='mb-4 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-sm text-red-600'>
@@ -156,7 +154,8 @@ const EditVotingRecordsModal: React.FC<EditVotingRecordsModalProps> = ({
               </thead>
               <tbody>
                 {rows.map((row) => {
-                  const dirty = row.result !== initialResults[row.votingRecordId];
+                  const dirty =
+                    row.result !== initialResults[row.votingRecordId];
                   const optionList = choices.includes(row.result)
                     ? choices
                     : [...choices, row.result];
@@ -187,9 +186,7 @@ const EditVotingRecordsModal: React.FC<EditVotingRecordsModalProps> = ({
                       <td className='px-4 py-3 text-right align-middle'>
                         <button
                           type='button'
-                          disabled={
-                            !dirty || savingId === row.votingRecordId
-                          }
+                          disabled={!dirty || savingId === row.votingRecordId}
                           onClick={() => saveRow(row)}
                           className='rounded-lg bg-[#C8102E] px-4 py-2 text-sm font-semibold text-white hover:bg-[#A8102E] disabled:cursor-not-allowed disabled:opacity-60'
                         >

--- a/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
+++ b/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
@@ -1,42 +1,49 @@
 'use client';
 
-import React, { useState } from 'react';
-import { VotingEventWithRelations } from '@/types';
+import React, { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { VOTING_TYPES } from '@/utils/consts';
+import { getVoteCounts } from '@/utils/voting_utils';
+import { useActiveVotingEvents } from '@/hooks/useActiveVotingEvents';
 import { formatResultLabel } from './votingDisplayUtils';
 import EditVotingRecordsModal from './EditVotingRecordsModal';
 
 interface OngoingVotingPanelProps {
-  events: VotingEventWithRelations[];
-  loading: boolean;
-  onRefresh: () => void;
+  refreshTrigger?: number;
 }
 
 const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
-  events,
-  loading,
-  onRefresh,
+  refreshTrigger = 0,
 }) => {
   const { user } = useAuth();
+  const {
+    events: ongoingEvents,
+    loading,
+    error,
+    refresh,
+  } = useActiveVotingEvents();
   const [editEventId, setEditEventId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (refreshTrigger === 0) return;
+    void refresh();
+  }, [refreshTrigger, refresh]);
 
   if (!user || user.role !== 'EBOARD') {
     return null;
   }
-
-  const ongoingEvents = events
-    .filter((e) => !e.deletedAt && !e.endedAt)
-    .sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
 
   return (
     <div className='mt-8 bg-white rounded-2xl shadow-lg p-6 border border-gray-100'>
       <div className='flex items-center justify-between mb-4'>
         <h2 className='text-lg font-semibold text-gray-900'>Ongoing Voting</h2>
       </div>
+
+      {error && (
+        <p className='mb-3 text-sm text-red-600' role='alert'>
+          {error}
+        </p>
+      )}
 
       {loading ? (
         <p className='text-sm text-gray-500'>Loading ongoing votes…</p>
@@ -66,16 +73,8 @@ const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
             </thead>
             <tbody>
               {ongoingEvents.map((event) => {
-                const records =
-                  (event.votingRecords || []).filter((r) => !r.deletedAt) || [];
-                const counts = records.reduce<Record<string, number>>(
-                  (acc, record) => {
-                    acc[record.result] = (acc[record.result] || 0) + 1;
-                    return acc;
-                  },
-                  {},
-                );
-                const totalVotes = Object.values(counts).reduce(
+                const voteCounts = getVoteCounts(event);
+                const totalVotes = Object.values(voteCounts).reduce(
                   (sum, n) => sum + n,
                   0,
                 );
@@ -114,7 +113,7 @@ const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
                         </span>
                       ) : (
                         <div className='flex flex-wrap gap-2 items-center'>
-                          {Object.entries(counts).map(([key, value]) => (
+                          {Object.entries(voteCounts).map(([key, value]) => (
                             <span
                               key={key}
                               className='inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700'
@@ -159,7 +158,7 @@ const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
           votingEventId={editEventId}
           onClose={() => setEditEventId(null)}
           onSaved={() => {
-            onRefresh();
+            void refresh();
           }}
         />
       )}

--- a/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
+++ b/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
@@ -1,19 +1,11 @@
 'use client';
 
 import React, { useState } from 'react';
-import { VotingEventApiData, VotingRecordApiData } from '@/types';
+import { VotingEventWithRelations } from '@/types';
 import { useAuth } from '@/contexts/AuthContext';
 import { VOTING_TYPES } from '@/utils/consts';
 import { formatResultLabel } from './votingDisplayUtils';
 import EditVotingRecordsModal from './EditVotingRecordsModal';
-
-type VotingEventWithRelations = VotingEventApiData & {
-  meeting?: {
-    name: string;
-    date: string;
-  };
-  votingRecords?: VotingRecordApiData[];
-};
 
 interface OngoingVotingPanelProps {
   events: VotingEventWithRelations[];
@@ -34,7 +26,7 @@ const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
   }
 
   const ongoingEvents = events
-    .filter((e) => !e.deletedAt)
+    .filter((e) => !e.deletedAt && !e.endedAt)
     .sort(
       (a, b) =>
         new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
@@ -87,7 +79,8 @@ const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
                   (sum, n) => sum + n,
                   0,
                 );
-                const isSecret = event.voteType === VOTING_TYPES.SECRET_BALLOT.key;
+                const isSecret =
+                  event.voteType === VOTING_TYPES.SECRET_BALLOT.key;
 
                 return (
                   <tr
@@ -146,12 +139,10 @@ const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
                       ) : (
                         <button
                           type='button'
-                          onClick={() =>
-                            setEditEventId(event.votingEventId)
-                          }
+                          onClick={() => setEditEventId(event.votingEventId)}
                           className='rounded-lg bg-[#C8102E] px-4 py-2 text-sm font-semibold text-white hover:bg-[#A8102E]'
                         >
-                          Edit voting records
+                          Edit Voting Records
                         </button>
                       )}
                     </td>

--- a/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
+++ b/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import React, { useState } from 'react';
+import { VotingEventApiData, VotingRecordApiData } from '@/types';
+import { useAuth } from '@/contexts/AuthContext';
+import { VOTING_TYPES } from '@/utils/consts';
+import { formatResultLabel } from './votingDisplayUtils';
+import EditVotingRecordsModal from './EditVotingRecordsModal';
+
+type VotingEventWithRelations = VotingEventApiData & {
+  meeting?: {
+    name: string;
+    date: string;
+  };
+  votingRecords?: VotingRecordApiData[];
+};
+
+interface OngoingVotingPanelProps {
+  events: VotingEventWithRelations[];
+  loading: boolean;
+  onRefresh: () => void;
+}
+
+const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
+  events,
+  loading,
+  onRefresh,
+}) => {
+  const { user } = useAuth();
+  const [editEventId, setEditEventId] = useState<string | null>(null);
+
+  if (!user || user.role !== 'EBOARD') {
+    return null;
+  }
+
+  const ongoingEvents = events
+    .filter((e) => !e.deletedAt)
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
+  return (
+    <div className='mt-8 bg-white rounded-2xl shadow-lg p-6 border border-gray-100'>
+      <div className='flex items-center justify-between mb-4'>
+        <h2 className='text-lg font-semibold text-gray-900'>Ongoing Voting</h2>
+      </div>
+
+      {loading ? (
+        <p className='text-sm text-gray-500'>Loading ongoing votes…</p>
+      ) : ongoingEvents.length === 0 ? (
+        <p className='text-sm text-gray-500'>No voting events in progress.</p>
+      ) : (
+        <div className='overflow-x-auto'>
+          <table className='w-full text-sm'>
+            <thead>
+              <tr className='border-b border-gray-200'>
+                <th className='text-left py-3 px-4 font-medium text-gray-900'>
+                  Meeting / Date
+                </th>
+                <th className='text-left py-3 px-4 font-medium text-gray-900'>
+                  Question
+                </th>
+                <th className='text-left py-3 px-4 font-medium text-gray-900'>
+                  Vote Type
+                </th>
+                <th className='text-left py-3 px-4 font-medium text-gray-900'>
+                  Results
+                </th>
+                <th className='text-left py-3 px-4 font-medium text-gray-900'>
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {ongoingEvents.map((event) => {
+                const records =
+                  (event.votingRecords || []).filter((r) => !r.deletedAt) || [];
+                const counts = records.reduce<Record<string, number>>(
+                  (acc, record) => {
+                    acc[record.result] = (acc[record.result] || 0) + 1;
+                    return acc;
+                  },
+                  {},
+                );
+                const totalVotes = Object.values(counts).reduce(
+                  (sum, n) => sum + n,
+                  0,
+                );
+                const isSecret = event.voteType === VOTING_TYPES.SECRET_BALLOT.key;
+
+                return (
+                  <tr
+                    key={event.votingEventId}
+                    className='border-b border-gray-100 hover:bg-gray-50'
+                  >
+                    <td className='py-3 px-4 align-top'>
+                      <div className='text-gray-900 font-medium'>
+                        {event.meeting?.name ?? 'Unknown meeting'}
+                      </div>
+                      <div className='text-xs text-gray-500'>
+                        {event.meeting?.date
+                          ? event.meeting.date
+                          : new Date(event.createdAt).toLocaleDateString()}
+                      </div>
+                    </td>
+                    <td className='py-3 px-4 align-top'>
+                      <div className='text-gray-900'>
+                        {event.name || 'Untitled vote'}
+                      </div>
+                    </td>
+                    <td className='py-3 px-4 align-top'>
+                      <span className='inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700'>
+                        {event.voteType}
+                      </span>
+                    </td>
+                    <td className='py-3 px-4 align-top'>
+                      {totalVotes === 0 ? (
+                        <span className='text-xs text-gray-500'>
+                          No votes recorded
+                        </span>
+                      ) : (
+                        <div className='flex flex-wrap gap-2 items-center'>
+                          {Object.entries(counts).map(([key, value]) => (
+                            <span
+                              key={key}
+                              className='inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700'
+                            >
+                              {formatResultLabel(key)}: {value}
+                            </span>
+                          ))}
+                          <span className='inline-flex items-center rounded-full bg-gray-50 px-2 py-1 text-xs text-gray-500'>
+                            Total: {totalVotes}
+                          </span>
+                        </div>
+                      )}
+                    </td>
+                    <td className='py-3 px-4 align-top'>
+                      {isSecret ? (
+                        <span
+                          className='text-xs text-gray-500'
+                          title='Per-voter records are not editable for secret ballot'
+                        >
+                          —
+                        </span>
+                      ) : (
+                        <button
+                          type='button'
+                          onClick={() =>
+                            setEditEventId(event.votingEventId)
+                          }
+                          className='rounded-lg bg-[#C8102E] px-4 py-2 text-sm font-semibold text-white hover:bg-[#A8102E]'
+                        >
+                          Edit voting records
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {editEventId && (
+        <EditVotingRecordsModal
+          votingEventId={editEventId}
+          onClose={() => setEditEventId(null)}
+          onSaved={() => {
+            onRefresh();
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default OngoingVotingPanel;

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -10,11 +10,13 @@ interface VotingAdminPanelProps {
   meetings: MeetingApiData[];
 
   onEventCreated?: (event: VotingEventWithRelations) => void;
+  onVotingEventsMutated?: () => void | Promise<void>;
 }
 
 const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
   meetings,
   onEventCreated,
+  onVotingEventsMutated,
 }) => {
   // ─── States ────────────────────────────────────────────────────────────────
 
@@ -127,6 +129,7 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
       if (onEventCreated) {
         onEventCreated(event);
       }
+      await onVotingEventsMutated?.();
       setName('');
       setOptions([]);
     } catch (err) {
@@ -164,6 +167,7 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
       const updated: VotingEventWithRelations = await res.json();
       setCurrentEvent(updated);
       await refreshActiveEvent();
+      await onVotingEventsMutated?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error');
     } finally {

--- a/attendance-manager/src/components/voting/VotingPage.tsx
+++ b/attendance-manager/src/components/voting/VotingPage.tsx
@@ -12,6 +12,7 @@ const VotingPage: React.FC = () => {
   const [deleteEvent, setDeleteEvent] =
     useState<VotingEventWithRelations | null>(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
+  const [ongoingRefreshTrigger, setOngoingRefreshTrigger] = useState(0);
 
   const loadMeetingsAndEvents = useCallback(async () => {
     setEventsLoading(true);
@@ -30,6 +31,7 @@ const VotingPage: React.FC = () => {
         const eventsData: VotingEventWithRelations[] = await eventsRes.json();
         setEvents(eventsData);
       }
+      setOngoingRefreshTrigger((n) => n + 1);
     } catch (error) {
       globalThis.console?.error('Failed to load meetings and events', error);
     } finally {
@@ -79,11 +81,7 @@ const VotingPage: React.FC = () => {
         meetings={meetings}
         onVotingEventsMutated={loadMeetingsAndEvents}
       />
-      <OngoingVotingPanel
-        events={events}
-        loading={eventsLoading}
-        onRefresh={loadMeetingsAndEvents}
-      />
+      <OngoingVotingPanel refreshTrigger={ongoingRefreshTrigger} />
       <VotingResultsPanel
         events={events}
         loading={eventsLoading}

--- a/attendance-manager/src/components/voting/VotingPage.tsx
+++ b/attendance-manager/src/components/voting/VotingPage.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { MeetingApiData, VotingEventWithRelations } from '@/types';
 import VotingAdminPanel from '@/components/voting/VotingAdminPanel';
+import OngoingVotingPanel from '@/components/voting/OngoingVotingPanel';
 import VotingResultsPanel from '@/components/voting/VotingResultsPanel';
 import DeleteVotingModal from '@/components/voting/DeleteVotingModal';
 
@@ -12,9 +13,9 @@ const VotingPage: React.FC = () => {
     useState<VotingEventWithRelations | null>(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
 
-  const refreshVotingData = async () => {
+  const loadMeetingsAndEvents = useCallback(async () => {
+    setEventsLoading(true);
     try {
-      setEventsLoading(true);
       const [meetingsRes, eventsRes] = await Promise.all([
         fetch('/api/meeting'),
         fetch('/api/voting-event'),
@@ -29,18 +30,17 @@ const VotingPage: React.FC = () => {
         const eventsData: VotingEventWithRelations[] = await eventsRes.json();
         setEvents(eventsData);
       }
-    } catch (err) {
-      globalThis.console?.error('Failed to refresh voting data:', err);
+    } catch (error) {
+      globalThis.console?.error('Failed to load meetings and events', error);
     } finally {
       setEventsLoading(false);
     }
-  };
-
-  useEffect(() => {
-    refreshVotingData();
   }, []);
 
-  // Soft-delete handler: sets deletedAt on the vote and refreshes list
+  useEffect(() => {
+    loadMeetingsAndEvents();
+  }, [loadMeetingsAndEvents]);
+
   const handleDeleteVotingEvent = async (votingEventId?: string | null) => {
     if (!votingEventId) return;
     try {
@@ -57,8 +57,7 @@ const VotingPage: React.FC = () => {
         throw new Error(err.error || 'Failed to delete voting event');
       }
 
-      // Refresh the data
-      await refreshVotingData();
+      await loadMeetingsAndEvents();
     } catch (err) {
       globalThis.console?.error('Failed to delete voting event', err);
       alert('Failed to delete voting event.');
@@ -76,7 +75,15 @@ const VotingPage: React.FC = () => {
           see a modal to submit their vote.
         </p>
       </div>
-      <VotingAdminPanel meetings={meetings} />
+      <VotingAdminPanel
+        meetings={meetings}
+        onVotingEventsMutated={loadMeetingsAndEvents}
+      />
+      <OngoingVotingPanel
+        events={events}
+        loading={eventsLoading}
+        onRefresh={loadMeetingsAndEvents}
+      />
       <VotingResultsPanel
         events={events}
         loading={eventsLoading}

--- a/attendance-manager/src/components/voting/votingDisplayUtils.ts
+++ b/attendance-manager/src/components/voting/votingDisplayUtils.ts
@@ -1,0 +1,13 @@
+// labels for vote result strings 
+export function formatResultLabel(result: string): string {
+  switch (result) {
+    case 'YES':
+      return 'Yes';
+    case 'NO':
+      return 'No';
+    case 'ABSTAIN':
+      return 'Abstain';
+    default:
+      return result.charAt(0) + result.slice(1).toLowerCase();
+  }
+}

--- a/attendance-manager/src/components/voting/votingDisplayUtils.ts
+++ b/attendance-manager/src/components/voting/votingDisplayUtils.ts
@@ -1,4 +1,4 @@
-// labels for vote result strings 
+// labels for vote result strings
 export function formatResultLabel(result: string): string {
   switch (result) {
     case 'YES':

--- a/attendance-manager/src/hooks/useActiveVotingEvents.ts
+++ b/attendance-manager/src/hooks/useActiveVotingEvents.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from 'react';
+import { VotingEventWithRelations } from '@/types';
+
+interface UseActiveVotingEventsOptions {
+  pollIntervalMs?: number;
+}
+
+interface UseActiveVotingEventsResult {
+  events: VotingEventWithRelations[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+// Polls GET /api/voting-event/active (VotingService.getActiveVotingEvents)
+export function useActiveVotingEvents(
+  options: UseActiveVotingEventsOptions = {},
+): UseActiveVotingEventsResult {
+  const { pollIntervalMs = 3000 } = options;
+  const [events, setEvents] = useState<VotingEventWithRelations[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setError(null);
+      const res = await fetch('/api/voting-event/active');
+      if (!res.ok) {
+        throw new Error(`Failed to fetch active voting events (${res.status})`);
+      }
+      const data: VotingEventWithRelations[] = await res.json();
+      const sorted = [...data].sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+      setEvents(sorted);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const id = window.setInterval(() => {
+      void refresh();
+    }, pollIntervalMs);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [refresh, pollIntervalMs]);
+
+  return { events, loading, error, refresh };
+}

--- a/attendance-manager/src/voting-record/__tests__/voting-record.test.ts
+++ b/attendance-manager/src/voting-record/__tests__/voting-record.test.ts
@@ -134,6 +134,24 @@ describe('VotingRecordService', () => {
     expect(firstRecord.votingEvent.meeting).toBeDefined();
     expect(firstRecord.votingEvent.meeting.meetingId).toBeDefined();
   });
+
+  it('should update a voting record', async () => {
+    const updated = await VotingRecordService.updateVotingRecord({
+      votingRecordId: testVotingRecordId,
+      result: 'NO',
+      updatedBy: 'admin-user',
+    });
+    expect(updated.result).toBe('NO');
+    expect(updated.updatedBy).toBe('admin-user');
+    expect(updated.votingEvent).toBeDefined();
+    expect(updated.votingEvent.meeting).toBeDefined();
+
+    const restored = await VotingRecordService.updateVotingRecord({
+      votingRecordId: testVotingRecordId,
+      result: 'YES',
+    });
+    expect(restored.result).toBe('YES');
+  });
 });
 
 describe('VotingRecordController', () => {
@@ -334,6 +352,116 @@ describe('VotingRecordController', () => {
       const responseData = await response.json();
       expect(responseData.updatedBy).toBeNull();
       await VotingRecordService.deleteVotingRecord(responseData.votingRecordId);
+    });
+  });
+
+  describe('PATCH updateVotingRecord', () => {
+    it('should update result for an ongoing event', async () => {
+      const mockRequest = {
+        json: async () => ({ result: 'NO', updatedBy: 'admin' }),
+      } as Request;
+
+      const response = await VotingRecordController.updateVotingRecord(
+        mockRequest,
+        { votingRecordId: testVotingRecordId },
+      );
+      expect(response.status).toBe(200);
+      const responseData = await response.json();
+      expect(responseData.result).toBe('NO');
+
+      const restoreRequest = {
+        json: async () => ({ result: 'YES' }),
+      } as Request;
+      const restore = await VotingRecordController.updateVotingRecord(
+        restoreRequest,
+        { votingRecordId: testVotingRecordId },
+      );
+      expect(restore.status).toBe(200);
+      const restored = await restore.json();
+      expect(restored.result).toBe('YES');
+    });
+
+    it('should return 404 for non-existent voting record', async () => {
+      const mockRequest = {
+        json: async () => ({ result: 'NO' }),
+      } as Request;
+      const response = await VotingRecordController.updateVotingRecord(
+        mockRequest,
+        { votingRecordId: '00000000-0000-0000-0000-000000000000' },
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it('should return 400 when voting event is completed', async () => {
+      await prisma.votingEvent.update({
+        where: { votingEventId: testVotingEventId },
+        data: { deletedAt: new Date() },
+      });
+      try {
+        const mockRequest = {
+          json: async () => ({ result: 'NO' }),
+        } as Request;
+        const response = await VotingRecordController.updateVotingRecord(
+          mockRequest,
+          { votingRecordId: testVotingRecordId },
+        );
+        expect(response.status).toBe(400);
+        const responseData = await response.json();
+        expect(responseData.error).toContain('completed');
+      } finally {
+        await prisma.votingEvent.update({
+          where: { votingEventId: testVotingEventId },
+          data: { deletedAt: null },
+        });
+      }
+    });
+
+    it('should return 403 for secret ballot event', async () => {
+      const event = await prisma.votingEvent.create({
+        data: {
+          meetingId: testMeetingId,
+          name: 'Secret ballot patch test',
+          voteType: 'SECRET_BALLOT',
+          options: ['Yes', 'No'],
+        },
+      });
+      const rec = await VotingRecordService.createVotingRecord({
+        votingEventId: event.votingEventId,
+        userId: testUserId,
+        result: 'Yes',
+      });
+      const mockRequest = {
+        json: async () => ({ result: 'No' }),
+      } as Request;
+      const response = await VotingRecordController.updateVotingRecord(
+        mockRequest,
+        { votingRecordId: rec.votingRecordId },
+      );
+      expect(response.status).toBe(403);
+      await VotingRecordService.deleteVotingRecord(rec.votingRecordId);
+      await VotingService.deleteVotingEvent(event.votingEventId);
+    });
+
+    it('should return 400 for invalid result', async () => {
+      const mockRequest = {
+        json: async () => ({ result: 'NOT_A_VALID_VOTE' }),
+      } as Request;
+      const response = await VotingRecordController.updateVotingRecord(
+        mockRequest,
+        { votingRecordId: testVotingRecordId },
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 when result is missing', async () => {
+      const mockRequest = {
+        json: async () => ({}),
+      } as Request;
+      const response = await VotingRecordController.updateVotingRecord(
+        mockRequest,
+        { votingRecordId: testVotingRecordId },
+      );
+      expect(response.status).toBe(400);
     });
   });
 });
@@ -701,5 +829,108 @@ describe('POST /api/voting-record', () => {
 
     expect(response.status).toBe(400);
     expect(data.error).toContain('Missing required fields');
+  });
+});
+
+describe('PATCH /api/voting-record/[votingRecordId]', () => {
+  let patchMeetingId: string;
+  let patchEventId: string;
+  let patchUserId: string;
+  let patchRecordId: string;
+  let patchRoleId: string;
+
+  beforeAll(async () => {
+    const role = await prisma.role.create({
+      data: { roleType: 'MEMBER' },
+    });
+    patchRoleId = role.roleId;
+
+    const user = await prisma.user.create({
+      data: {
+        userId: 'test-voting-record-user-patch-route',
+        supabaseAuthId: 'test-supabase-auth-id-patch-route',
+        nuid: '001234599',
+        email: 'votingrecordpatchroute@example.com',
+        firstName: 'Patch',
+        lastName: 'Route',
+        roleId: role.roleId,
+        password: null,
+      },
+    });
+    patchUserId = user.userId;
+
+    const meeting = await prisma.meeting.create({
+      data: {
+        name: 'PATCH Route Meeting',
+        date: '2025-08-04',
+        startTime: '10:00',
+        endTime: '11:00',
+        notes: 'Test notes',
+        type: 'REGULAR',
+      },
+    });
+    patchMeetingId = meeting.meetingId;
+
+    const votingEvent = await prisma.votingEvent.create({
+      data: {
+        meetingId: patchMeetingId,
+        name: 'PATCH Route Voting Event',
+        voteType: 'YES_NO',
+      },
+    });
+    patchEventId = votingEvent.votingEventId;
+
+    const votingRecord = await VotingRecordService.createVotingRecord({
+      votingEventId: patchEventId,
+      userId: patchUserId,
+      result: 'YES',
+    });
+    patchRecordId = votingRecord.votingRecordId;
+  });
+
+  afterAll(async () => {
+    await VotingRecordService.deleteVotingRecord(patchRecordId);
+    await VotingService.deleteVotingEvent(patchEventId);
+    await MeetingService.deleteMeeting(patchMeetingId);
+    await UsersService.deleteUser(patchUserId);
+    await UsersService.deleteRole(patchRoleId);
+  });
+
+  it('should update a voting record via PATCH route', async () => {
+    const { PATCH } = await import(
+      '../../app/api/voting-record/[votingRecordId]/route'
+    );
+    const req = new Request(
+      `http://localhost/api/voting-record/${patchRecordId}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          result: 'ABSTAIN',
+          updatedBy: 'route-patch-tester',
+        }),
+      },
+    );
+    const response = await PATCH(req, {
+      params: Promise.resolve({ votingRecordId: patchRecordId }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.result).toBe('ABSTAIN');
+    expect(data.updatedBy).toBe('route-patch-tester');
+
+    const restoreReq = new Request(
+      `http://localhost/api/voting-record/${patchRecordId}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ result: 'YES' }),
+      },
+    );
+    const restoreRes = await PATCH(restoreReq, {
+      params: Promise.resolve({ votingRecordId: patchRecordId }),
+    });
+    expect(restoreRes.status).toBe(200);
   });
 });

--- a/attendance-manager/src/voting-record/voting-record.controller.ts
+++ b/attendance-manager/src/voting-record/voting-record.controller.ts
@@ -1,7 +1,28 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '../lib/prisma';
-import { VOTING_TYPES } from '../utils/consts';
+import { VOTING_TYPES, YES_NO_OPTIONS } from '../utils/consts';
 import { VotingRecordService } from './voting-record.service';
+
+const ROLL_CALL_STYLE_RESULTS = new Set<string>([
+  ...Object.values(YES_NO_OPTIONS),
+  'YES',
+  'NO',
+  'ABSTAIN',
+]);
+
+function isValidVotingRecordResult(
+  voteType: string,
+  options: string[],
+  result: string,
+): boolean {
+  if (voteType === VOTING_TYPES.ROLL_CALL.key) {
+    return ROLL_CALL_STYLE_RESULTS.has(result);
+  }
+  if (options.length > 0) {
+    return options.includes(result);
+  }
+  return ROLL_CALL_STYLE_RESULTS.has(result);
+}
 
 export const VotingRecordController = {
   async getAllVotingRecords() {
@@ -75,6 +96,97 @@ export const VotingRecordController = {
         { error: error.message || 'Failed to create voting record' },
         { status: 400 },
       );
+    }
+  },
+
+  async updateVotingRecord(
+    request: Request,
+    params: { votingRecordId: string },
+  ) {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    if (
+      !body ||
+      typeof body !== 'object' ||
+      typeof (body as { result?: unknown }).result !== 'string'
+    ) {
+      return NextResponse.json(
+        { error: 'Missing or invalid field: result (string) is required' },
+        { status: 400 },
+      );
+    }
+
+    const { result, updatedBy } = body as {
+      result: string;
+      updatedBy?: unknown;
+    };
+
+    if (
+      updatedBy !== undefined &&
+      updatedBy !== null &&
+      typeof updatedBy !== 'string'
+    ) {
+      return NextResponse.json(
+        { error: 'updatedBy must be a string when provided' },
+        { status: 400 },
+      );
+    }
+
+    const record = await prisma.votingRecord.findUnique({
+      where: { votingRecordId: params.votingRecordId },
+      include: {
+        votingEvent: true,
+      },
+    });
+
+    if (!record || record.deletedAt) {
+      return NextResponse.json(
+        { error: 'Voting record not found' },
+        { status: 404 },
+      );
+    }
+
+    const event = record.votingEvent;
+    if (event.deletedAt) {
+      return NextResponse.json(
+        { error: 'Cannot edit voting records for a completed voting event' },
+        { status: 400 },
+      );
+    }
+
+    if (event.voteType === VOTING_TYPES.SECRET_BALLOT.key) {
+      return NextResponse.json(
+        {
+          error: 'Voting records cannot be edited for secret ballot events',
+        },
+        { status: 403 },
+      );
+    }
+
+    const options = Array.isArray(event.options) ? event.options : [];
+    if (!isValidVotingRecordResult(event.voteType, options, result)) {
+      return NextResponse.json(
+        { error: 'Invalid result for this voting event type' },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const updated = await VotingRecordService.updateVotingRecord({
+        votingRecordId: params.votingRecordId,
+        result,
+        ...(typeof updatedBy === 'string' ? { updatedBy } : {}),
+      });
+      return NextResponse.json(updated);
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to update voting record';
+      return NextResponse.json({ error: message }, { status: 400 });
     }
   },
 };

--- a/attendance-manager/src/voting-record/voting-record.controller.ts
+++ b/attendance-manager/src/voting-record/voting-record.controller.ts
@@ -3,7 +3,7 @@ import { prisma } from '../lib/prisma';
 import { VOTING_TYPES, YES_NO_OPTIONS } from '../utils/consts';
 import { VotingRecordService } from './voting-record.service';
 
-const ROLL_CALL_STYLE_RESULTS = new Set<string>([
+const rollCallStyleResults = new Set<string>([
   ...Object.values(YES_NO_OPTIONS),
   'YES',
   'NO',
@@ -16,12 +16,12 @@ function isValidVotingRecordResult(
   result: string,
 ): boolean {
   if (voteType === VOTING_TYPES.ROLL_CALL.key) {
-    return ROLL_CALL_STYLE_RESULTS.has(result);
+    return rollCallStyleResults.has(result);
   }
   if (options.length > 0) {
     return options.includes(result);
   }
-  return ROLL_CALL_STYLE_RESULTS.has(result);
+  return rollCallStyleResults.has(result);
 }
 
 export const VotingRecordController = {
@@ -185,7 +185,9 @@ export const VotingRecordController = {
       return NextResponse.json(updated);
     } catch (error: unknown) {
       const message =
-        error instanceof Error ? error.message : 'Failed to update voting record';
+        error instanceof Error
+          ? error.message
+          : 'Failed to update voting record';
       return NextResponse.json({ error: message }, { status: 400 });
     }
   },

--- a/attendance-manager/src/voting-record/voting-record.service.ts
+++ b/attendance-manager/src/voting-record/voting-record.service.ts
@@ -48,6 +48,29 @@ export const VotingRecordService = {
       },
     });
   },
+  async updateVotingRecord(data: {
+    votingRecordId: string;
+    result: string;
+    updatedBy?: string;
+  }) {
+    return prisma.votingRecord.update({
+      where: { votingRecordId: data.votingRecordId },
+      data: {
+        result: data.result,
+        ...(data.updatedBy !== undefined
+          ? { updatedBy: data.updatedBy }
+          : {}),
+      },
+      include: {
+        votingEvent: {
+          include: {
+            meeting: true,
+          },
+        },
+      },
+    });
+  },
+
   async deleteVotingRecord(votingRecordId: string) {
     return prisma.votingRecord.delete({
       where: { votingRecordId },

--- a/attendance-manager/src/voting-record/voting-record.service.ts
+++ b/attendance-manager/src/voting-record/voting-record.service.ts
@@ -57,9 +57,7 @@ export const VotingRecordService = {
       where: { votingRecordId: data.votingRecordId },
       data: {
         result: data.result,
-        ...(data.updatedBy !== undefined
-          ? { updatedBy: data.updatedBy }
-          : {}),
+        ...(data.updatedBy !== undefined ? { updatedBy: data.updatedBy } : {}),
       },
       include: {
         votingEvent: {

--- a/attendance-manager/src/voting/__tests__/voting.test.ts
+++ b/attendance-manager/src/voting/__tests__/voting.test.ts
@@ -666,7 +666,7 @@ describe('GET /api/voting-event/[id]', () => {
   });
 });
 
-describe('ROLL_CALL results include voter names', () => {
+describe('Per-voter voting results include voter names (non-secret ballot)', () => {
   let testMeetingId: string;
   let testRoleId: string;
   let user1Id: string;
@@ -816,8 +816,8 @@ describe('ROLL_CALL results include voter names', () => {
     expect(record2.user.lastName).toBe('CallTwo');
   });
 
-  // non-ROLL_CALL events should not receive user name data
-  it('does not inject user names for non-ROLL_CALL events', async () => {
+  // YES_NO and other non-secret types get voter names (e.g. admin edit modal, results UI)
+  it('returns votingRecords with user first/last names for YES_NO events', async () => {
     const nonRollCallEvent = await prisma.votingEvent.create({
       data: {
         meetingId: testMeetingId,
@@ -846,7 +846,9 @@ describe('ROLL_CALL results include voter names', () => {
     expect(response.status).toBe(200);
     expect(data.voteType).toBe('YES_NO');
     expect(Array.isArray(data.votingRecords)).toBe(true);
-    expect(data.votingRecords[0]).not.toHaveProperty('user');
+    expect(data.votingRecords[0].user).toBeDefined();
+    expect(data.votingRecords[0].user.firstName).toBe('Roll');
+    expect(data.votingRecords[0].user.lastName).toBe('CallOne');
 
     await prisma.votingRecord.deleteMany({
       where: { votingEventId: nonRollCallEvent.votingEventId },

--- a/attendance-manager/src/voting/voting.service.ts
+++ b/attendance-manager/src/voting/voting.service.ts
@@ -138,7 +138,7 @@ async function attachVoterNamesToVotingEvent<
   T extends { voteType: string; votingRecords?: any[] },
 >(event: T | null): Promise<T | null> {
   if (!event) return event;
-  if (event.voteType !== 'ROLL_CALL') return event;
+  if (event.voteType === SECRET_BALLOT) return event;
   if (!event.votingRecords || event.votingRecords.length === 0) return event;
 
   const userIds = Array.from(


### PR DESCRIPTION
- added Ongoing Voting panel for active votes (same style as past results)
- added Edit Voting Records per row → modal with event title, voter name, current vote, and dropdown to change + save
- PATCH voting record API used for saves, blocks edits when the event is over or secret ballot
- attaches voter names on records for non–secret-ballot events so the modal can show full names
- refetch the voting list after create/end so there's no manual refresh

<img width="800" height="190" alt="Screenshot 2026-04-04 at 8 28 54 pm" src="https://github.com/user-attachments/assets/3592debb-30ca-4e52-bd54-7d23bd6dab48" />

<img width="900" height="400" alt="Screenshot 2026-04-04 at 8 29 16 pm" src="https://github.com/user-attachments/assets/2055b771-696a-47ae-8a3f-2911b3e77a30" />