### PR TITLE
ATM-175 fix active vote state lost on page refresh

### DIFF
--- a/attendance-manager/src/app/api/meeting/upcoming/route.ts
+++ b/attendance-manager/src/app/api/meeting/upcoming/route.ts
@@ -1,0 +1,5 @@
+import { MeetingController } from '@/meeting/meeting.controller';
+
+export async function GET() {
+  return MeetingController.listUpcomingMeetings();
+}

--- a/attendance-manager/src/components/voting/ActiveVoteCard.tsx
+++ b/attendance-manager/src/components/voting/ActiveVoteCard.tsx
@@ -21,6 +21,7 @@ const ActiveVoteCard: React.FC<ActiveVoteCardProps> = ({
   const voteTypeLabel = getVoteTypeLabel(event.voteType);
   const voteCounts = getVoteCounts(event);
   const totalVotes = Object.values(voteCounts).reduce((sum, n) => sum + n, 0);
+
   return (
     <div className='rounded-xl border border-gray-100 bg-gray-50 p-5 text-sm'>
       <div className='flex items-start justify-between gap-2'>

--- a/attendance-manager/src/components/voting/ActiveVoteCard.tsx
+++ b/attendance-manager/src/components/voting/ActiveVoteCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { VotingEventWithRelations } from '@/types';
-import { getVoteCounts } from '@/utils/voting_utils';
-import { VOTING_TYPES } from '@/utils/consts';
+import { getVoteCounts, getVoteTypeLabel } from '@/utils/voting_utils';
 import { Building2, Calendar, ClipboardList } from 'lucide-react';
 import VoteBreakdown from './VoteBreakdown';
 
@@ -19,9 +18,7 @@ const ActiveVoteCard: React.FC<ActiveVoteCardProps> = ({
   endError,
 }) => {
   const meeting = event.meeting;
-  const voteTypeLabel =
-    Object.values(VOTING_TYPES).find((t) => t.key === event.voteType)?.value ??
-    event.voteType;
+  const voteTypeLabel = getVoteTypeLabel(event.voteType);
   const voteCounts = getVoteCounts(event);
   const totalVotes = Object.values(voteCounts).reduce((sum, n) => sum + n, 0);
   return (
@@ -37,7 +34,7 @@ const ActiveVoteCard: React.FC<ActiveVoteCardProps> = ({
         </button>
       </div>
 
-      <div className='flex flex-wrap gap-x-5 gap-y-1 mt-1 text-sm text-gray-500'>
+      <div className='flex flex-wrap gap-x-5 gap-y-1.5 mt-2 text-sm text-gray-500'>
         <div className='flex items-center gap-1.5'>
           <ClipboardList className='h-3.5 w-3.5 shrink-0' />
           <span>{voteTypeLabel}</span>

--- a/attendance-manager/src/components/voting/ActiveVoteCard.tsx
+++ b/attendance-manager/src/components/voting/ActiveVoteCard.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { VotingEventWithRelations } from '@/types';
+import { getVoteCounts } from '@/utils/voting_utils';
+import { VOTING_TYPES } from '@/utils/consts';
+import { Building2, Calendar, ClipboardList } from 'lucide-react';
+import VoteBreakdown from './VoteBreakdown';
+
+interface ActiveVoteCardProps {
+  event: VotingEventWithRelations;
+  eligible: number;
+  onEnd: (votingEventId: string) => void;
+  endError: string | null | undefined;
+}
+
+const ActiveVoteCard: React.FC<ActiveVoteCardProps> = ({
+  event,
+  eligible,
+  onEnd,
+  endError,
+}) => {
+  const meeting = event.meeting;
+  const voteTypeLabel =
+    Object.values(VOTING_TYPES).find((t) => t.key === event.voteType)?.value ??
+    event.voteType;
+  const voteCounts = getVoteCounts(event);
+  const totalVotes = Object.values(voteCounts).reduce((sum, n) => sum + n, 0);
+  return (
+    <div className='rounded-xl border border-gray-100 bg-gray-50 p-5 text-sm'>
+      <div className='flex items-start justify-between gap-2'>
+        <div className='font-medium text-gray-900'>{event.name}</div>
+        <button
+          type='button'
+          onClick={() => onEnd(event.votingEventId)}
+          className='shrink-0 px-4 py-1 bg-primary text-white rounded-lg text-sm font-medium hover:bg-primary-dark disabled:opacity-60 disabled:cursor-not-allowed'
+        >
+          Close Vote
+        </button>
+      </div>
+
+      <div className='flex flex-wrap gap-x-5 gap-y-1 mt-1 text-sm text-gray-500'>
+        <div className='flex items-center gap-1.5'>
+          <ClipboardList className='h-3.5 w-3.5 shrink-0' />
+          <span>{voteTypeLabel}</span>
+        </div>
+        {meeting && (
+          <>
+            <div className='flex items-center gap-1.5'>
+              <Calendar className='h-3.5 w-3.5 shrink-0' />
+              <span>{meeting.date}</span>
+            </div>
+            <div className='flex items-center gap-1.5'>
+              <Building2 className='h-3.5 w-3.5 shrink-0' />
+              <span>{meeting.name}</span>
+            </div>
+          </>
+        )}
+      </div>
+
+      <VoteBreakdown
+        event={event}
+        eligible={eligible}
+        voteCounts={voteCounts}
+        totalVotes={totalVotes}
+      />
+
+      {endError && (
+        <p className='mt-2 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2'>
+          {endError}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ActiveVoteCard;

--- a/attendance-manager/src/components/voting/ActiveVoteCard.tsx
+++ b/attendance-manager/src/components/voting/ActiveVoteCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { VotingEventWithRelations } from '@/types';
-import { getVoteCounts, getVoteTypeLabel } from '@/utils/voting_utils';
+import { VoteType, getVoteTypeLabel } from '@/utils/consts';
+import { getVoteCounts } from '@/utils/voting_utils';
 import { Building2, Calendar, ClipboardList } from 'lucide-react';
 import VoteBreakdown from './VoteBreakdown';
 
@@ -18,7 +19,7 @@ const ActiveVoteCard: React.FC<ActiveVoteCardProps> = ({
   endError,
 }) => {
   const meeting = event.meeting;
-  const voteTypeLabel = getVoteTypeLabel(event.voteType);
+  const voteTypeLabel = getVoteTypeLabel(event.voteType as VoteType);
   const voteCounts = getVoteCounts(event);
   const totalVotes = Object.values(voteCounts).reduce((sum, n) => sum + n, 0);
 

--- a/attendance-manager/src/components/voting/ActiveVotingModal.tsx
+++ b/attendance-manager/src/components/voting/ActiveVotingModal.tsx
@@ -52,17 +52,14 @@ const ActiveVotingModal: React.FC<ActiveVotingModalProps> = ({
       });
 
       if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to submit vote');
+        setError('Failed to submit vote.');
+        return;
       }
 
       setHasVoted(true);
-      if (onVoted) {
-        onVoted();
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      setError(message);
+      onVoted?.();
+    } catch {
+      setError('Failed to submit vote.');
     } finally {
       setSubmitting(false);
     }
@@ -70,7 +67,7 @@ const ActiveVotingModal: React.FC<ActiveVotingModalProps> = ({
 
   return (
     <div className='fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50'>
-      <div className='bg-white rounded-2xl shadow-xl p-6 w-full max-w-md mx-4 relative'>
+      <div className='bg-white rounded-2xl shadow-xl p-6 w-full max-w-md mx-4'>
         <div className='flex items-start justify-between mb-2'>
           <h2 className='text-xl font-semibold text-gray-900'>Active Vote</h2>
           <button
@@ -136,7 +133,7 @@ const ActiveVotingModal: React.FC<ActiveVotingModalProps> = ({
             </p>
           )}
 
-          <div className='flex justify-end space-x-2 pt-2'>
+          <div className='flex justify-end pt-2'>
             <button
               type='submit'
               disabled={submitting}

--- a/attendance-manager/src/components/voting/ActiveVotingModal.tsx
+++ b/attendance-manager/src/components/voting/ActiveVotingModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { X } from 'lucide-react';
 import { VotingEventApiData } from '@/types';
 import { useAuth } from '@/contexts/AuthContext';
-import { YES_NO_OPTIONS } from '@/utils/consts';
+import { yesNoOptions } from '@/utils/consts';
 
 interface ActiveVotingModalProps {
   event: VotingEventApiData;
@@ -95,7 +95,7 @@ const ActiveVotingModal: React.FC<ActiveVotingModalProps> = ({
               Please select your vote:
             </legend>
             {event.voteType === 'ROLL_CALL' ? (
-              Object.values(YES_NO_OPTIONS).map((option) => (
+              Object.values(yesNoOptions).map((option) => (
                 <label
                   key={option}
                   className='flex items-center space-x-2 text-sm text-gray-800'

--- a/attendance-manager/src/components/voting/CreateVoteForm.tsx
+++ b/attendance-manager/src/components/voting/CreateVoteForm.tsx
@@ -1,0 +1,216 @@
+import React, { useMemo, useState } from 'react';
+import { MeetingApiData } from '@/types';
+import { VOTING_TYPES } from '@/utils/consts';
+import { X } from 'lucide-react';
+
+const FIXED_OPTIONS = ['Abstain', 'No Confidence'] as const;
+
+interface CreateVoteFormProps {
+  meetings: MeetingApiData[];
+  userId: string;
+  onCreated: () => Promise<void>;
+}
+
+const CreateVoteForm: React.FC<CreateVoteFormProps> = ({
+  meetings,
+  userId,
+  onCreated,
+}) => {
+  // Form fields
+  const [meetingId, setMeetingId] = useState('');
+  const [name, setName] = useState('');
+  const [voteType, setVoteType] = useState(VOTING_TYPES.ROLL_CALL.key);
+  const [options, setOptions] = useState<string[]>([]);
+
+  // Submission state
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const meetingsForDropdown = useMemo(() => {
+    const today = new Date();
+    const todayStr =
+      today.getFullYear() +
+      '-' +
+      String(today.getMonth() + 1).padStart(2, '0') +
+      '-' +
+      String(today.getDate()).padStart(2, '0');
+    const upcoming = meetings.filter((m) => {
+      const raw = (m.date && String(m.date).trim()) || '';
+      const meetingDateStr = raw.slice(0, 10);
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(meetingDateStr)) return true;
+      return meetingDateStr >= todayStr;
+    });
+    return upcoming.length > 0 ? upcoming : meetings;
+  }, [meetings]);
+
+  const addOption = () => {
+    setOptions((prev) => {
+      const count = prev.filter((o) => o.startsWith('Option')).length;
+      return [...prev, count === 0 ? 'Option' : `Option ${count + 1}`];
+    });
+  };
+
+  const removeOption = (index: number) => {
+    setOptions((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!meetingId || !name.trim()) {
+      setError('Please select a meeting and enter a vote name.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/voting-event', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          meetingId,
+          name,
+          voteType,
+          updatedBy: userId,
+          options:
+            voteType === VOTING_TYPES.SECRET_BALLOT.key
+              ? [...FIXED_OPTIONS, ...options]
+              : options,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to create voting event');
+      }
+
+      await onCreated();
+      setMeetingId('');
+      setName('');
+      setOptions([]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className='space-y-4'>
+      <div>
+        <label className='block text-sm font-medium text-gray-700 mb-1'>
+          Meeting
+        </label>
+        <select
+          value={meetingId}
+          onChange={(e) => setMeetingId(e.target.value)}
+          className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary'
+        >
+          <option value=''>Select a meeting</option>
+          {meetingsForDropdown.map((m) => (
+            <option key={m.meetingId} value={m.meetingId}>
+              {m.date} — {m.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className='block text-sm font-medium text-gray-700 mb-1'>
+          Question / Name
+        </label>
+        <input
+          type='text'
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary'
+          placeholder='Enter the vote question or title'
+        />
+      </div>
+
+      <div>
+        <label className='block text-sm font-medium text-gray-700 mb-1'>
+          Vote Type
+        </label>
+        <select
+          value={voteType}
+          onChange={(e) => setVoteType(e.target.value)}
+          className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary'
+        >
+          {Object.values(VOTING_TYPES).map((type) => (
+            <option key={type.key} value={type.key}>
+              {type.value}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {voteType === VOTING_TYPES.SECRET_BALLOT.key && (
+        <div>
+          <label className='block text-sm font-medium text-gray-700 mb-1'>
+            Options
+          </label>
+          <div className='space-y-2'>
+            {FIXED_OPTIONS.map((fixed) => (
+              <div key={fixed} className='relative'>
+                <input
+                  type='text'
+                  value={fixed}
+                  readOnly
+                  disabled
+                  className='w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-600'
+                />
+              </div>
+            ))}
+            {options.map((option, index) => (
+              <div key={index} className='relative'>
+                <input
+                  type='text'
+                  value={option}
+                  onChange={(e) => {
+                    const newOptions = [...options];
+                    newOptions[index] = e.target.value;
+                    setOptions(newOptions);
+                  }}
+                  className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary pr-8'
+                />
+                <X
+                  onClick={() => removeOption(index)}
+                  className='absolute right-2 top-1/2 -translate-y-1/2 text-red-500 text-sm hover:bg-red-50 rounded px-1'
+                />
+              </div>
+            ))}
+          </div>
+          <div className='flex justify-end mt-2'>
+            <button
+              type='button'
+              onClick={addOption}
+              className='text-sm font-medium hover:underline'
+            >
+              + Add Option
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <p className='text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2'>
+          {error}
+        </p>
+      )}
+
+      <div className='pt-2'>
+        <button
+          type='submit'
+          disabled={isSubmitting}
+          className='px-4 py-2 bg-primary text-white rounded-lg text-sm font-medium hover:bg-primary-dark disabled:opacity-60 disabled:cursor-not-allowed'
+        >
+          {isSubmitting ? 'Starting…' : 'Create & Start Voting Event'}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default CreateVoteForm;

--- a/attendance-manager/src/components/voting/CreateVoteForm.tsx
+++ b/attendance-manager/src/components/voting/CreateVoteForm.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { MeetingApiData } from '@/types';
-import { votingTypes, VoteType } from '@/utils/consts';
-import { getVoteTypeLabel } from '@/utils/voting_utils';
+import { VoteType, getVoteTypeLabel } from '@/utils/consts';
 import { X } from 'lucide-react';
 
 const FIXED_OPTIONS = ['Abstain', 'No Confidence'] as const;
@@ -20,7 +19,7 @@ const CreateVoteForm: React.FC<CreateVoteFormProps> = ({
   // Form fields
   const [meetingId, setMeetingId] = useState('');
   const [name, setName] = useState('');
-  const [voteType, setVoteType] = useState<VoteType>(votingTypes.rollCall);
+  const [voteType, setVoteType] = useState<VoteType>(VoteType.rollCall);
   const [options, setOptions] = useState<string[]>([]);
 
   // Submission state
@@ -58,7 +57,7 @@ const CreateVoteForm: React.FC<CreateVoteFormProps> = ({
           voteType,
           updatedBy: userId,
           options:
-            voteType === votingTypes.secretBallot
+            voteType === VoteType.secretBallot
               ? [...FIXED_OPTIONS, ...options]
               : options,
         }),
@@ -122,7 +121,7 @@ const CreateVoteForm: React.FC<CreateVoteFormProps> = ({
           onChange={(e) => setVoteType(e.target.value as VoteType)}
           className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary'
         >
-          {Object.values(votingTypes).map((key) => (
+          {Object.values(VoteType).map((key) => (
             <option key={key} value={key}>
               {getVoteTypeLabel(key)}
             </option>
@@ -130,7 +129,7 @@ const CreateVoteForm: React.FC<CreateVoteFormProps> = ({
         </select>
       </div>
 
-      {voteType === votingTypes.secretBallot && (
+      {voteType === VoteType.secretBallot && (
         <div>
           <label className='block text-sm font-medium text-gray-700 mb-1'>
             Options

--- a/attendance-manager/src/components/voting/CreateVoteForm.tsx
+++ b/attendance-manager/src/components/voting/CreateVoteForm.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { MeetingApiData } from '@/types';
-import { VOTING_TYPES } from '@/utils/consts';
+import { votingTypes, VoteType } from '@/utils/consts';
+import { getVoteTypeLabel } from '@/utils/voting_utils';
 import { X } from 'lucide-react';
 
 const FIXED_OPTIONS = ['Abstain', 'No Confidence'] as const;
@@ -19,29 +20,12 @@ const CreateVoteForm: React.FC<CreateVoteFormProps> = ({
   // Form fields
   const [meetingId, setMeetingId] = useState('');
   const [name, setName] = useState('');
-  const [voteType, setVoteType] = useState(VOTING_TYPES.ROLL_CALL.key);
+  const [voteType, setVoteType] = useState<VoteType>(votingTypes.rollCall);
   const [options, setOptions] = useState<string[]>([]);
 
   // Submission state
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const meetingsForDropdown = useMemo(() => {
-    const today = new Date();
-    const todayStr =
-      today.getFullYear() +
-      '-' +
-      String(today.getMonth() + 1).padStart(2, '0') +
-      '-' +
-      String(today.getDate()).padStart(2, '0');
-    const upcoming = meetings.filter((m) => {
-      const raw = (m.date && String(m.date).trim()) || '';
-      const meetingDateStr = raw.slice(0, 10);
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(meetingDateStr)) return true;
-      return meetingDateStr >= todayStr;
-    });
-    return upcoming.length > 0 ? upcoming : meetings;
-  }, [meetings]);
 
   const addOption = () => {
     setOptions((prev) => {
@@ -74,7 +58,7 @@ const CreateVoteForm: React.FC<CreateVoteFormProps> = ({
           voteType,
           updatedBy: userId,
           options:
-            voteType === VOTING_TYPES.SECRET_BALLOT.key
+            voteType === votingTypes.secretBallot
               ? [...FIXED_OPTIONS, ...options]
               : options,
         }),
@@ -108,7 +92,7 @@ const CreateVoteForm: React.FC<CreateVoteFormProps> = ({
           className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary'
         >
           <option value=''>Select a meeting</option>
-          {meetingsForDropdown.map((m) => (
+          {meetings.map((m) => (
             <option key={m.meetingId} value={m.meetingId}>
               {m.date} — {m.name}
             </option>
@@ -135,18 +119,18 @@ const CreateVoteForm: React.FC<CreateVoteFormProps> = ({
         </label>
         <select
           value={voteType}
-          onChange={(e) => setVoteType(e.target.value)}
+          onChange={(e) => setVoteType(e.target.value as VoteType)}
           className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary'
         >
-          {Object.values(VOTING_TYPES).map((type) => (
-            <option key={type.key} value={type.key}>
-              {type.value}
+          {Object.values(votingTypes).map((key) => (
+            <option key={key} value={key}>
+              {getVoteTypeLabel(key)}
             </option>
           ))}
         </select>
       </div>
 
-      {voteType === VOTING_TYPES.SECRET_BALLOT.key && (
+      {voteType === votingTypes.secretBallot && (
         <div>
           <label className='block text-sm font-medium text-gray-700 mb-1'>
             Options

--- a/attendance-manager/src/components/voting/CreateVoteForm.tsx
+++ b/attendance-manager/src/components/voting/CreateVoteForm.tsx
@@ -65,16 +65,16 @@ const CreateVoteForm: React.FC<CreateVoteFormProps> = ({
       });
 
       if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to create voting event');
+        setError('Failed to create voting event.');
+        return;
       }
 
       await onCreated();
       setMeetingId('');
       setName('');
       setOptions([]);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
+    } catch {
+      setError('Failed to create voting event.');
     } finally {
       setIsSubmitting(false);
     }

--- a/attendance-manager/src/components/voting/EditVotingRecordsModal.tsx
+++ b/attendance-manager/src/components/voting/EditVotingRecordsModal.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { VotingEventApiData, VotingRecordApiData } from '@/types';
 import { useAuth } from '@/contexts/AuthContext';
-import { VOTING_TYPES, YES_NO_OPTIONS } from '@/utils/consts';
+import { votingTypes, yesNoOptions } from '@/utils/consts';
 import { formatResultLabel } from './votingDisplayUtils';
 
 interface EditVotingRecordsModalProps {
@@ -13,8 +13,8 @@ interface EditVotingRecordsModalProps {
 }
 
 function choiceOptionsForEvent(event: VotingEventApiData): string[] {
-  if (event.voteType === VOTING_TYPES.ROLL_CALL.key) {
-    return Object.values(YES_NO_OPTIONS);
+  if (event.voteType === votingTypes.rollCall) {
+    return Object.values(yesNoOptions);
   }
   if (event.options && event.options.length > 0) {
     return event.options;

--- a/attendance-manager/src/components/voting/EditVotingRecordsModal.tsx
+++ b/attendance-manager/src/components/voting/EditVotingRecordsModal.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { VotingEventApiData, VotingRecordApiData } from '@/types';
 import { useAuth } from '@/contexts/AuthContext';
-import { votingTypes, yesNoOptions } from '@/utils/consts';
+import { VoteType, yesNoOptions } from '@/utils/consts';
 import { formatResultLabel } from './votingDisplayUtils';
 
 interface EditVotingRecordsModalProps {
@@ -13,7 +13,7 @@ interface EditVotingRecordsModalProps {
 }
 
 function choiceOptionsForEvent(event: VotingEventApiData): string[] {
-  if (event.voteType === votingTypes.rollCall) {
+  if (event.voteType === VoteType.rollCall) {
     return Object.values(yesNoOptions);
   }
   if (event.options && event.options.length > 0) {

--- a/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
+++ b/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import { votingTypes } from '@/utils/consts';
+import { VoteType } from '@/utils/consts';
 import { getVoteCounts } from '@/utils/voting_utils';
 import { useActiveVotingEvents } from '@/hooks/useActiveVotingEvents';
 import { formatResultLabel } from './votingDisplayUtils';
@@ -78,7 +78,7 @@ const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
                   (sum, n) => sum + n,
                   0,
                 );
-                const isSecret = event.voteType === votingTypes.secretBallot;
+                const isSecret = event.voteType === VoteType.secretBallot;
 
                 return (
                   <tr

--- a/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
+++ b/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
@@ -78,8 +78,7 @@ const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
                   (sum, n) => sum + n,
                   0,
                 );
-                const isSecret =
-                  event.voteType === votingTypes.secretBallot;
+                const isSecret = event.voteType === votingTypes.secretBallot;
 
                 return (
                   <tr

--- a/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
+++ b/attendance-manager/src/components/voting/OngoingVotingPanel.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import { VOTING_TYPES } from '@/utils/consts';
+import { votingTypes } from '@/utils/consts';
 import { getVoteCounts } from '@/utils/voting_utils';
 import { useActiveVotingEvents } from '@/hooks/useActiveVotingEvents';
 import { formatResultLabel } from './votingDisplayUtils';
@@ -79,7 +79,7 @@ const OngoingVotingPanel: React.FC<OngoingVotingPanelProps> = ({
                   0,
                 );
                 const isSecret =
-                  event.voteType === VOTING_TYPES.SECRET_BALLOT.key;
+                  event.voteType === votingTypes.secretBallot;
 
                 return (
                   <tr

--- a/attendance-manager/src/components/voting/VoteBreakdown.tsx
+++ b/attendance-manager/src/components/voting/VoteBreakdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { VotingEventWithRelations } from '@/types';
-import { YES_NO_OPTIONS } from '@/utils/consts';
+import { yesNoOptions } from '@/utils/consts';
 import { Vote } from 'lucide-react';
 
 const optionRank = (o: string) =>
@@ -40,7 +40,7 @@ const VoteBreakdown: React.FC<VoteBreakdownProps> = ({
   const opts =
     event.options.length > 0
       ? [...event.options].sort((a, b) => optionRank(a) - optionRank(b))
-      : Object.values(YES_NO_OPTIONS);
+      : Object.values(yesNoOptions);
 
   if (opts.length === 0) return null;
 

--- a/attendance-manager/src/components/voting/VoteBreakdown.tsx
+++ b/attendance-manager/src/components/voting/VoteBreakdown.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { VotingEventWithRelations } from '@/types';
+import { YES_NO_OPTIONS } from '@/utils/consts';
+import { Vote } from 'lucide-react';
+
+const optionRank = (o: string) =>
+  o === 'Abstain' ? 2 : o === 'No Confidence' ? 1 : 0;
+
+const optionColorClass = new Map([
+  ['Yes', 'bg-vote-yes'],
+  ['No', 'bg-vote-no'],
+  ['Abstain', 'bg-vote-abstain'],
+  ['No Confidence', 'bg-vote-no-confidence'],
+]);
+const FALLBACK_COLOR_CLASSES = [
+  'bg-vote-f1',
+  'bg-vote-f2',
+  'bg-vote-f3',
+  'bg-vote-f4',
+  'bg-vote-f5',
+];
+
+const getOptionColorClass = (opt: string, idx: number): string =>
+  optionColorClass.get(opt) ??
+  FALLBACK_COLOR_CLASSES[idx % FALLBACK_COLOR_CLASSES.length];
+
+interface VoteBreakdownProps {
+  event: VotingEventWithRelations;
+  eligible: number;
+  voteCounts: Record<string, number>;
+  totalVotes: number;
+}
+
+const VoteBreakdown: React.FC<VoteBreakdownProps> = ({
+  event,
+  eligible,
+  voteCounts,
+  totalVotes,
+}) => {
+  const opts =
+    event.options.length > 0
+      ? [...event.options].sort((a, b) => optionRank(a) - optionRank(b))
+      : Object.values(YES_NO_OPTIONS);
+
+  if (opts.length === 0) return null;
+
+  const participationPct =
+    eligible > 0
+      ? Math.round((Math.min(totalVotes, eligible) / eligible) * 100)
+      : null;
+
+  return (
+    <div className='mt-4 pt-4 border-t border-gray-200'>
+      <div className='flex items-center gap-1.5 text-primary font-medium mb-3'>
+        <Vote className='h-4 w-4 shrink-0' />
+        <span>
+          {totalVotes}/{eligible > 0 ? eligible : '—'} votes
+          {participationPct !== null && ` (${participationPct}%)`}
+        </span>
+      </div>
+      {totalVotes > 0 && (
+        <div className='h-10 w-full rounded-xl overflow-hidden flex'>
+          {opts.map((opt, idx) => {
+            const count = voteCounts[opt] ?? 0;
+            const barPct = Math.round((count / totalVotes) * 100);
+            return (
+              <div
+                key={opt}
+                className={`h-full flex items-center justify-center overflow-hidden transition-all duration-500 ${getOptionColorClass(opt, idx)}`}
+                style={{ width: `${barPct}%` }}
+                title={`${opt}: ${count} (${barPct}%)`}
+              >
+                {barPct >= 8 && (
+                  <span className='text-sm font-medium text-gray-800 whitespace-nowrap px-2 truncate'>
+                    {opt} · {count} · {barPct}%
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default VoteBreakdown;

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -210,48 +210,37 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
                     Close Vote
                   </button>
                 </div>
-                <div className='space-y-1.5'>
-                  {meeting && (
-                    <div className='flex items-baseline gap-2'>
-                      <span className='w-20 shrink-0 text-gray-400'>
-                        Meeting
-                      </span>
-                      <span className='font-medium text-gray-900'>
-                        {meeting.date} — {meeting.name}
-                      </span>
-                    </div>
-                  )}
-                  <div className='flex items-baseline gap-2'>
-                    <span className='w-20 shrink-0 text-gray-400'>Type</span>
-                    <span className='font-medium text-gray-900'>
-                      {voteTypeLabel}
-                    </span>
-                  </div>
-                  <div className='flex items-center gap-2 flex-wrap'>
-                    <span className='w-20 shrink-0 text-gray-400'>Votes</span>
-                    <span className='font-semibold text-gray-900'>
-                      {totalVotes} total
-                    </span>
-                    {(() => {
-                      const opts =
-                        event.voteType === VOTING_TYPES.SECRET_BALLOT.key
-                          ? [...event.options].sort(
-                              (a, b) => optionRank(a) - optionRank(b),
-                            )
-                          : Object.keys(voteCounts);
-                      return opts.map((opt) => (
-                        <span
-                          key={opt}
-                          className='inline-flex items-center gap-1 rounded-md bg-gray-200 px-2 py-0.5 text-xs text-gray-600'
-                        >
-                          {opt}
-                          <span className='font-semibold text-gray-900'>
-                            {voteCounts[opt] ?? 0}
-                          </span>
+                <p className='text-gray-500'>
+                  {[
+                    meeting && `${meeting.date} — ${meeting.name}`,
+                    voteTypeLabel,
+                  ]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </p>
+                <div className='mt-3 pt-3 border-t border-gray-200 flex items-center gap-2 flex-wrap'>
+                  <span className='font-semibold text-gray-900'>
+                    {totalVotes} total
+                  </span>
+                  {(() => {
+                    const opts =
+                      event.voteType === VOTING_TYPES.SECRET_BALLOT.key
+                        ? [...event.options].sort(
+                            (a, b) => optionRank(a) - optionRank(b),
+                          )
+                        : Object.keys(voteCounts);
+                    return opts.map((opt) => (
+                      <span
+                        key={opt}
+                        className='inline-flex items-center gap-1 rounded-md bg-gray-200 px-2 py-0.5 text-xs text-gray-600'
+                      >
+                        {opt}
+                        <span className='font-semibold text-gray-900'>
+                          {voteCounts[opt] ?? 0}
                         </span>
-                      ));
-                    })()}
-                  </div>
+                      </span>
+                    ));
+                  })()}
                 </div>
                 {endError && (
                   <p className='mt-2 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2'>

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -198,10 +198,20 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
                 key={event.votingEventId}
                 className='rounded-xl border border-gray-100 bg-gray-50 p-4 text-sm'
               >
-                <div className='flex items-start justify-between gap-2 mb-2'>
-                  <span className='font-medium text-gray-900'>
-                    {event.name}
-                  </span>
+                <div className='flex items-start justify-between gap-2'>
+                  <div className='min-w-0'>
+                    <span className='font-medium text-gray-900'>
+                      {event.name}
+                    </span>
+                    <span className='ml-2 text-gray-400'>
+                      {[
+                        voteTypeLabel,
+                        meeting && `${meeting.date} — ${meeting.name}`,
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </span>
+                  </div>
                   <button
                     type='button'
                     onClick={() => handleEnd(event.votingEventId)}
@@ -210,14 +220,6 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
                     Close Vote
                   </button>
                 </div>
-                <p className='text-gray-500'>
-                  {[
-                    meeting && `${meeting.date} — ${meeting.name}`,
-                    voteTypeLabel,
-                  ]
-                    .filter(Boolean)
-                    .join(' · ')}
-                </p>
                 <div className='mt-3 pt-3 border-t border-gray-200 flex items-center gap-2 flex-wrap'>
                   <span className='font-semibold text-gray-900'>
                     {totalVotes} total

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -196,7 +196,7 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
             return (
               <div
                 key={event.votingEventId}
-                className='rounded-xl border border-gray-100 bg-gray-50 p-4 text-sm'
+                className='rounded-xl border border-gray-100 bg-gray-50 p-5 text-sm'
               >
                 <div className='flex items-start justify-between gap-2'>
                   <div className='min-w-0'>
@@ -206,7 +206,7 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
                     <span className='ml-2 text-gray-400'>
                       {[
                         voteTypeLabel,
-                        meeting && `${meeting.date} — ${meeting.name}`,
+                        meeting && `${meeting.date} · ${meeting.name}`,
                       ]
                         .filter(Boolean)
                         .join(' · ')}
@@ -220,7 +220,7 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
                     Close Vote
                   </button>
                 </div>
-                <div className='mt-3 pt-3 border-t border-gray-200 flex items-center gap-2 flex-wrap'>
+                <div className='mt-4 pt-4 border-t border-gray-200 flex items-center gap-2 flex-wrap'>
                   <span className='font-semibold text-gray-900'>
                     {totalVotes} total
                   </span>

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -6,9 +6,13 @@ import { useActiveVotingEvent } from '@/hooks/useActiveVotingEvent';
 import { X } from 'lucide-react';
 import { VOTING_TYPES } from '@/utils/consts';
 
+const FIXED_OPTIONS = ['Abstain', 'No Confidence'] as const;
+
+const optionRank = (o: string) =>
+  o === 'Abstain' ? 2 : o === 'No Confidence' ? 1 : 0;
+
 interface VotingAdminPanelProps {
   meetings: MeetingApiData[];
-
   onEventCreated?: (event: VotingEventWithRelations) => void;
   onVotingEventsMutated?: () => void | Promise<void>;
 }
@@ -19,23 +23,19 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
   onVotingEventsMutated,
 }) => {
   // ─── States ────────────────────────────────────────────────────────────────
-
   const { user } = useAuth();
   const [meetingId, setMeetingId] = useState<string>('');
   const [name, setName] = useState<string>('');
   const [voteType, setVoteType] = useState<string>(VOTING_TYPES.ROLL_CALL.key);
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [currentEvent, setCurrentEvent] =
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [endErrors, setEndErrors] = useState<Record<string, string>>({});
+  const [pendingEvent, setPendingEvent] =
     useState<VotingEventWithRelations | null>(null);
   const [options, setOptions] = useState<string[]>([]);
 
-  // Fixed options for Secret Ballot
-  const fixedOptions = ['Abstain', 'No Confidence'];
-
   // ─── Functions ─────────────────────────────────────────────────────────────
   const addOption = () => {
-    // Add default value 'Option', let them rename it later
     setOptions((prev) => {
       const count = prev.filter((o) => o.startsWith('Option')).length;
       const newOption = count === 0 ? 'Option' : `Option ${count + 1}`;
@@ -48,20 +48,21 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
   };
 
   // ─── Hooks ─────────────────────────────────────────────────────────────────
-  const { activeEvent, refresh: refreshActiveEvent } = useActiveVotingEvent();
+  const {
+    activeEvents,
+    loading: activeEventLoading,
+    refresh: refreshActiveEvent,
+  } = useActiveVotingEvent();
 
-  const effectiveCurrentEvent = currentEvent ?? activeEvent;
-  const hasActiveEvent = !!(
-    effectiveCurrentEvent &&
-    !effectiveCurrentEvent.deletedAt &&
-    !effectiveCurrentEvent.endedAt
-  );
-
-  const activeVoteCounts =
-    hasActiveEvent && activeEvent ? getVoteCounts(activeEvent) : null;
-  const activeTotalVotes = activeVoteCounts
-    ? Object.values(activeVoteCounts).reduce((sum, n) => sum + n, 0)
-    : 0;
+  // Merge a freshly created event into the display list until the next poll
+  const displayedActiveEvents = useMemo(() => {
+    if (!pendingEvent || pendingEvent.endedAt || pendingEvent.deletedAt)
+      return activeEvents;
+    const alreadyPolled = activeEvents.some(
+      (e) => e.votingEventId === pendingEvent.votingEventId,
+    );
+    return alreadyPolled ? activeEvents : [pendingEvent, ...activeEvents];
+  }, [activeEvents, pendingEvent]);
 
   const meetingsForDropdown = useMemo(() => {
     const today = new Date();
@@ -87,34 +88,26 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (hasActiveEvent) {
-      setError(
-        'There is already an active voting event. Please end it before starting a new one.',
-      );
-      return;
-    }
     if (!meetingId || !name.trim()) {
-      setError('Please select a meeting and enter a vote name.');
+      setCreateError('Please select a meeting and enter a vote name.');
       return;
     }
 
     setSubmitting(true);
-    setError(null);
+    setCreateError(null);
 
     try {
       const res = await fetch('/api/voting-event', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           meetingId,
           name,
           voteType,
           updatedBy: user.id,
           options:
-            voteType === 'SECRET_BALLOT'
-              ? [...fixedOptions, ...options]
+            voteType === VOTING_TYPES.SECRET_BALLOT.key
+              ? [...FIXED_OPTIONS, ...options]
               : options,
         }),
       });
@@ -125,224 +118,275 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
       }
 
       const event: VotingEventWithRelations = await res.json();
-      setCurrentEvent(event);
+      setPendingEvent(event);
       if (onEventCreated) {
         onEventCreated(event);
       }
       await onVotingEventsMutated?.();
+      setMeetingId('');
       setName('');
       setOptions([]);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      setError(message);
+      setCreateError(err instanceof Error ? err.message : 'Unknown error');
     } finally {
       setSubmitting(false);
     }
   };
 
-  const handleEnd = async () => {
-    if (!effectiveCurrentEvent) {
-      setError('No active event');
-      return;
-    }
-
-    setSubmitting(true);
-    setError(null);
+  const handleEnd = async (votingEventId: string) => {
+    setEndErrors((prev) => ({ ...prev, [votingEventId]: '' }));
 
     try {
-      const res = await fetch(
-        `/api/voting-event/${effectiveCurrentEvent.votingEventId}`,
-        {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ end: true, updatedBy: user?.id }),
-        },
-      );
+      const res = await fetch(`/api/voting-event/${votingEventId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ end: true, updatedBy: user?.id }),
+      });
 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         throw new Error(data.error || 'Failed to end voting event');
       }
 
-      const updated: VotingEventWithRelations = await res.json();
-      setCurrentEvent(updated);
+      if (pendingEvent?.votingEventId === votingEventId) {
+        setPendingEvent(null);
+      }
       await refreshActiveEvent();
       await onVotingEventsMutated?.();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
-    } finally {
-      setCurrentEvent(null);
-      setSubmitting(false);
+      setEndErrors((prev) => ({
+        ...prev,
+        [votingEventId]: err instanceof Error ? err.message : 'Unknown error',
+      }));
     }
   };
 
   return (
     <div className='mt-6 bg-white rounded-2xl shadow-lg p-6 border border-gray-100'>
-      <h2 className='text-lg font-semibold text-gray-900 mb-4'>
-        Voting Controls
-      </h2>
+      <div className='flex items-center justify-between mb-4'>
+        <h2 className='text-lg font-semibold text-gray-900'>Voting Controls</h2>
+        {displayedActiveEvents.length > 0 && (
+          <span className='inline-flex items-center gap-1.5 rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-700'>
+            <span className='h-1.5 w-1.5 rounded-full bg-green-500' />
+            {displayedActiveEvents.length === 1
+              ? 'Vote In Progress'
+              : `${displayedActiveEvents.length} Votes In Progress`}
+          </span>
+        )}
+      </div>
 
-      <form onSubmit={handleCreate} className='space-y-4'>
-        <div>
-          <label className='block text-sm font-medium text-gray-700 mb-1'>
-            Meeting
-          </label>
-          <select
-            value={meetingId}
-            onChange={(e) => setMeetingId(e.target.value)}
-            className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E]'
-          >
-            <option value=''>Select a meeting</option>
-            {meetingsForDropdown.map((m) => (
-              <option key={m.meetingId} value={m.meetingId}>
-                {m.date} — {m.name}
-              </option>
-            ))}
-          </select>
+      {activeEventLoading && displayedActiveEvents.length === 0 && (
+        <p className='mb-4 text-sm text-gray-500'>Checking for active votes…</p>
+      )}
+
+      {displayedActiveEvents.length > 0 && (
+        <div className='space-y-2'>
+          {displayedActiveEvents.map((event) => {
+            const meeting = event.meeting;
+            const voteTypeLabel =
+              Object.values(VOTING_TYPES).find((t) => t.key === event.voteType)
+                ?.value ?? event.voteType;
+            const endError = endErrors[event.votingEventId];
+            const voteCounts = getVoteCounts(event);
+            const totalVotes = Object.values(voteCounts).reduce(
+              (sum, n) => sum + n,
+              0,
+            );
+
+            return (
+              <div
+                key={event.votingEventId}
+                className='rounded-xl border border-gray-100 bg-gray-50 p-4 text-sm'
+              >
+                <div className='flex items-start justify-between gap-2 mb-2'>
+                  <span className='font-medium text-gray-900'>
+                    {event.name}
+                  </span>
+                  <button
+                    type='button'
+                    onClick={() => handleEnd(event.votingEventId)}
+                    className='shrink-0 px-4 py-1 bg-gray-800 text-white rounded-lg text-sm font-medium hover:bg-gray-900 disabled:opacity-60 disabled:cursor-not-allowed'
+                  >
+                    Close Vote
+                  </button>
+                </div>
+                <div className='space-y-1.5'>
+                  {meeting && (
+                    <div className='flex items-baseline gap-2'>
+                      <span className='w-20 shrink-0 text-gray-400'>
+                        Meeting
+                      </span>
+                      <span className='font-medium text-gray-900'>
+                        {meeting.date} — {meeting.name}
+                      </span>
+                    </div>
+                  )}
+                  <div className='flex items-baseline gap-2'>
+                    <span className='w-20 shrink-0 text-gray-400'>Type</span>
+                    <span className='font-medium text-gray-900'>
+                      {voteTypeLabel}
+                    </span>
+                  </div>
+                  {event.voteType === VOTING_TYPES.SECRET_BALLOT.key &&
+                    event.options.length > 0 && (
+                      <div className='flex items-start gap-2'>
+                        <span className='w-20 shrink-0 text-gray-400'>
+                          Options
+                        </span>
+                        <div className='flex flex-wrap gap-1'>
+                          {[...event.options]
+                            .sort((a, b) => optionRank(a) - optionRank(b))
+                            .map((opt) => (
+                              <span
+                                key={opt}
+                                className='rounded-md bg-gray-200 px-2 py-0.5 text-xs font-medium text-gray-700'
+                              >
+                                {opt}
+                              </span>
+                            ))}
+                        </div>
+                      </div>
+                    )}
+                  <div className='flex items-baseline gap-2'>
+                    <span className='w-20 shrink-0 text-gray-400'>Votes</span>
+                    <span className='font-medium text-gray-900'>
+                      {totalVotes}
+                      {totalVotes > 0 && (
+                        <span className='ml-2 font-normal text-gray-500'>
+                          {Object.entries(voteCounts)
+                            .map(([k, v]) => `${k}: ${v}`)
+                            .join(' · ')}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                </div>
+                {endError && (
+                  <p className='mt-2 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2'>
+                    {endError}
+                  </p>
+                )}
+              </div>
+            );
+          })}
         </div>
+      )}
 
-        <div>
-          <label className='block text-sm font-medium text-gray-700 mb-1'>
-            Question / Name
-          </label>
-          <input
-            type='text'
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E]'
-            placeholder='Enter the vote question or title'
-          />
-        </div>
-
-        <div>
-          <label className='block text-sm font-medium text-gray-700 mb-1'>
-            Vote Type
-          </label>
-          <select
-            value={voteType}
-            onChange={(e) => setVoteType(e.target.value)}
-            className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E]'
-          >
-            {Object.values(VOTING_TYPES).map((type) => (
-              <option value={type.key}>{type.value}</option>
-            ))}
-          </select>
-        </div>
-
-        {voteType === 'SECRET_BALLOT' && (
+      {!activeEventLoading && displayedActiveEvents.length === 0 && (
+        <form onSubmit={handleCreate} className='space-y-4'>
           <div>
             <label className='block text-sm font-medium text-gray-700 mb-1'>
-              Options
+              Meeting
             </label>
-            <div className='space-y-2'>
-              {/* Shows two mandatory options */}
-              {fixedOptions.map((fixed, idx) => (
-                <div key={`fixed-${idx}`} className='relative'>
-                  <input
-                    type='text'
-                    value={fixed}
-                    readOnly
-                    disabled
-                    className='w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-600'
-                  />
-                </div>
+            <select
+              value={meetingId}
+              onChange={(e) => setMeetingId(e.target.value)}
+              className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E]'
+            >
+              <option value=''>Select a meeting</option>
+              {meetingsForDropdown.map((m) => (
+                <option key={m.meetingId} value={m.meetingId}>
+                  {m.date} — {m.name}
+                </option>
               ))}
-
-              {/* User-added options */}
-              {options.map((option, index) => (
-                <div key={index} className='relative'>
-                  <input
-                    type='text'
-                    value={option}
-                    onChange={(e) => {
-                      const newOptions = [...options];
-                      newOptions[index] = e.target.value;
-                      setOptions(newOptions);
-                    }}
-                    className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E] pr-8' // add padding for the x
-                  />
-                  <X
-                    onClick={() => removeOption(option)}
-                    className='absolute right-2 top-1/2 -translate-y-1/2 text-red-500 text-sm hover:bg-red-50 rounded px-1'
-                  />
-                </div>
-              ))}
-            </div>
-            <div className='flex justify-end mt-2'>
-              <button
-                type='button'
-                onClick={(e) => {
-                  e.stopPropagation();
-                  addOption();
-                }}
-                className='text-sm font-medium hover:underline'
-              >
-                + Add Option
-              </button>
-            </div>
+            </select>
           </div>
-        )}
 
-        {error && (
-          <p className='text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2'>
-            {error}
-          </p>
-        )}
+          <div>
+            <label className='block text-sm font-medium text-gray-700 mb-1'>
+              Question / Name
+            </label>
+            <input
+              type='text'
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E]'
+              placeholder='Enter the vote question or title'
+            />
+          </div>
 
-        <div className='flex items-center justify-between pt-2'>
-          <button
-            type='submit'
-            disabled={submitting || hasActiveEvent}
-            className='px-4 py-2 bg-[#C8102E] text-white rounded-lg text-sm font-medium hover:bg-[#A8102E] disabled:opacity-60 disabled:cursor-not-allowed'
-          >
-            {submitting ? 'Starting…' : 'Create & Start Voting Event'}
-          </button>
-
-          {hasActiveEvent && (
-            <div className='flex items-center space-x-3'>
-              <p className='text-xs text-gray-600'>
-                Active vote:{' '}
-                <span className='font-medium'>
-                  {effectiveCurrentEvent?.name ?? 'In progress'}
-                </span>
-              </p>
-              <button
-                type='button'
-                onClick={handleEnd}
-                disabled={submitting}
-                className='px-4 py-2 bg-gray-800 text-white rounded-lg text-sm font-medium hover:bg-gray-900 disabled:opacity-60 disabled:cursor-not-allowed'
-              >
-                End Current Voting Event
-              </button>
-            </div>
-          )}
-        </div>
-      </form>
-
-      {hasActiveEvent && activeVoteCounts && (
-        <div className='mt-4 bg-gray-50 rounded-xl border border-gray-200 p-4'>
-          <h3 className='text-sm font-semibold text-gray-800 mb-3'>
-            Ongoing Vote Progress
-          </h3>
-          <p className='text-sm text-gray-600 mb-2'>
-            Total votes received:{' '}
-            <span className='font-semibold text-gray-900'>
-              {activeTotalVotes}
-            </span>
-          </p>
-          {activeTotalVotes > 0 && (
-            <div className='flex flex-wrap gap-2'>
-              {Object.entries(activeVoteCounts).map(([key, value]) => (
-                <span
-                  key={key}
-                  className='inline-flex items-center rounded-full bg-white border border-gray-200 px-2 py-1 text-xs font-medium text-gray-700'
-                >
-                  {key}: {value}
-                </span>
+          <div>
+            <label className='block text-sm font-medium text-gray-700 mb-1'>
+              Vote Type
+            </label>
+            <select
+              value={voteType}
+              onChange={(e) => setVoteType(e.target.value)}
+              className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E]'
+            >
+              {Object.values(VOTING_TYPES).map((type) => (
+                <option key={type.key} value={type.key}>
+                  {type.value}
+                </option>
               ))}
+            </select>
+          </div>
+
+          {voteType === VOTING_TYPES.SECRET_BALLOT.key && (
+            <div>
+              <label className='block text-sm font-medium text-gray-700 mb-1'>
+                Options
+              </label>
+              <div className='space-y-2'>
+                {FIXED_OPTIONS.map((fixed) => (
+                  <div key={fixed} className='relative'>
+                    <input
+                      type='text'
+                      value={fixed}
+                      readOnly
+                      disabled
+                      className='w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-600'
+                    />
+                  </div>
+                ))}
+
+                {options.map((option, index) => (
+                  <div key={index} className='relative'>
+                    <input
+                      type='text'
+                      value={option}
+                      onChange={(e) => {
+                        const newOptions = [...options];
+                        newOptions[index] = e.target.value;
+                        setOptions(newOptions);
+                      }}
+                      className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E] pr-8'
+                    />
+                    <X
+                      onClick={() => removeOption(option)}
+                      className='absolute right-2 top-1/2 -translate-y-1/2 text-red-500 text-sm hover:bg-red-50 rounded px-1'
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className='flex justify-end mt-2'>
+                <button
+                  type='button'
+                  onClick={addOption}
+                  className='text-sm font-medium hover:underline'
+                >
+                  + Add Option
+                </button>
+              </div>
             </div>
           )}
-        </div>
+
+          {createError && (
+            <p className='text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2'>
+              {createError}
+            </p>
+          )}
+
+          <div className='pt-2'>
+            <button
+              type='submit'
+              disabled={submitting}
+              className='px-4 py-2 bg-[#C8102E] text-white rounded-lg text-sm font-medium hover:bg-[#A8102E] disabled:opacity-60 disabled:cursor-not-allowed'
+            >
+              {submitting ? 'Starting…' : 'Create & Start Voting Event'}
+            </button>
+          </div>
+        </form>
       )}
     </div>
   );

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -1,93 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { MeetingApiData, VotingEventWithRelations } from '@/types';
-import { getVoteCounts } from '@/utils/voting_utils';
+import React, { useEffect, useState } from 'react';
+import { MeetingApiData } from '@/types';
 import { useAuth } from '@/contexts/AuthContext';
 import { useActiveVotingEvent } from '@/hooks/useActiveVotingEvent';
-import { X } from 'lucide-react';
-import { VOTING_TYPES, YES_NO_OPTIONS } from '@/utils/consts';
-
-const FIXED_OPTIONS = ['Abstain', 'No Confidence'] as const;
-
-const optionRank = (o: string) =>
-  o === 'Abstain' ? 2 : o === 'No Confidence' ? 1 : 0;
-
-const optionColors = new Map([
-  ['Yes', '#bbf7d0'],
-  ['No', '#fecaca'],
-  ['Abstain', '#e5e7eb'],
-  ['No Confidence', '#fde68a'],
-]);
-const FALLBACK_COLORS = ['#bfdbfe', '#ddd6fe', '#fbcfe8', '#99f6e4', '#fed7aa'];
-
-const getOptionColor = (opt: string, idx: number): string =>
-  optionColors.get(opt) ?? FALLBACK_COLORS[idx % FALLBACK_COLORS.length];
-
-// ─── VoteBreakdown ────────────────────────────────────────────────────────────
-
-interface VoteBreakdownProps {
-  event: VotingEventWithRelations;
-  eligible: number;
-  voteCounts: Record<string, number>;
-  totalVotes: number;
-}
-
-const VoteBreakdown: React.FC<VoteBreakdownProps> = ({
-  event,
-  eligible,
-  voteCounts,
-  totalVotes,
-}) => {
-  const opts =
-    event.options.length > 0
-      ? [...event.options].sort((a, b) => optionRank(a) - optionRank(b))
-      : Object.values(YES_NO_OPTIONS);
-
-  if (opts.length === 0) return null;
-
-  // Bar widths are out of eligible (gray remainder = not yet voted).
-  // Falls back to totalVotes if eligible is unavailable or stale.
-  const barDenom = Math.max(eligible, totalVotes);
-
-  return (
-    <div className='mt-4 pt-4 border-t border-gray-200'>
-      <p className='font-medium text-gray-900 mb-3'>
-        Total Votes Cast: {totalVotes}/{eligible > 0 ? eligible : '—'}
-        {eligible > 0 && (
-          <span className='ml-1'>
-            ({Math.round((Math.min(totalVotes, eligible) / eligible) * 100)}%)
-          </span>
-        )}
-      </p>
-      <div className='h-10 w-full rounded-xl overflow-hidden flex bg-gray-200'>
-        {opts.map((opt, idx) => {
-          const count = voteCounts[opt] ?? 0;
-          const barPct = barDenom > 0 ? (count / barDenom) * 100 : 0;
-          const labelPct =
-            totalVotes > 0 ? Math.round((count / totalVotes) * 100) : 0;
-          return (
-            <div
-              key={opt}
-              className='h-full flex items-center justify-center overflow-hidden transition-all duration-500'
-              style={{
-                width: `${barPct}%`,
-                backgroundColor: getOptionColor(opt, idx),
-              }}
-              title={`${opt}: ${count} (${labelPct}%)`}
-            >
-              {barPct >= 8 && (
-                <span className='text-sm font-medium text-gray-800 whitespace-nowrap px-2 truncate'>
-                  {opt} · {count} · {labelPct}%
-                </span>
-              )}
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-};
-
-// ─── VotingAdminPanel ─────────────────────────────────────────────────────────
+import ActiveVoteCard from './ActiveVoteCard';
+import CreateVoteForm from './CreateVoteForm';
 
 interface VotingAdminPanelProps {
   meetings: MeetingApiData[];
@@ -99,15 +15,10 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
   onVotingEventsMutated,
 }) => {
   const { user } = useAuth();
-  const [meetingId, setMeetingId] = useState<string>('');
-  const [name, setName] = useState<string>('');
-  const [voteType, setVoteType] = useState<string>(VOTING_TYPES.ROLL_CALL.key);
-  const [submitting, setSubmitting] = useState(false);
-  const [createError, setCreateError] = useState<string | null>(null);
+
+  // Per-event end errors
   const [endErrors, setEndErrors] = useState<Record<string, string | null>>({});
-  const [pendingEvent, setPendingEvent] =
-    useState<VotingEventWithRelations | null>(null);
-  const [options, setOptions] = useState<string[]>([]);
+  // Eligible voter counts keyed by meetingId
   const [eligibleCounts, setEligibleCounts] = useState<Record<string, number>>(
     {},
   );
@@ -118,39 +29,12 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
     refresh: refreshActiveEvent,
   } = useActiveVotingEvent();
 
-  // Merge a freshly created event into the display list until the next poll
-  const displayedActiveEvents = useMemo(() => {
-    if (!pendingEvent || pendingEvent.endedAt || pendingEvent.deletedAt)
-      return activeEvents;
-    const alreadyPolled = activeEvents.some(
-      (e) => e.votingEventId === pendingEvent.votingEventId,
-    );
-    return alreadyPolled ? activeEvents : [pendingEvent, ...activeEvents];
-  }, [activeEvents, pendingEvent]);
-
-  const meetingsForDropdown = useMemo(() => {
-    const today = new Date();
-    const todayStr =
-      today.getFullYear() +
-      '-' +
-      String(today.getMonth() + 1).padStart(2, '0') +
-      '-' +
-      String(today.getDate()).padStart(2, '0');
-    const upcoming = meetings.filter((m) => {
-      const raw = (m.date && String(m.date).trim()) || '';
-      const meetingDateStr = raw.slice(0, 10);
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(meetingDateStr)) return true;
-      return meetingDateStr >= todayStr;
-    });
-    return upcoming.length > 0 ? upcoming : meetings;
-  }, [meetings]);
-
   // Fetch eligible voter counts for any meeting not yet loaded.
   // eligibleCounts in deps is intentional: after each fetch completes the
   // effect re-runs, the filter finds no new IDs, and exits immediately.
   useEffect(() => {
     const unfetchedIds = [
-      ...new Set(displayedActiveEvents.map((e) => e.meetingId)),
+      ...new Set(activeEvents.map((e) => e.meetingId)),
     ].filter((mid) => !(mid in eligibleCounts));
 
     if (unfetchedIds.length === 0) return;
@@ -166,84 +50,21 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
         // eligible count is best-effort; silently ignore
       }
     });
-  }, [displayedActiveEvents, eligibleCounts]);
+  }, [activeEvents, eligibleCounts]);
 
-  if (!user || user.role !== 'EBOARD') {
-    return null;
-  }
-
-  const addOption = () => {
-    setOptions((prev) => {
-      const count = prev.filter((o) => o.startsWith('Option')).length;
-      return [...prev, count === 0 ? 'Option' : `Option ${count + 1}`];
-    });
-  };
-
-  const removeOption = (index: number) => {
-    setOptions((prev) => prev.filter((_, i) => i !== index));
-  };
-
-  const handleCreate = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!meetingId || !name.trim()) {
-      setCreateError('Please select a meeting and enter a vote name.');
-      return;
-    }
-
-    setSubmitting(true);
-    setCreateError(null);
-
-    try {
-      const res = await fetch('/api/voting-event', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          meetingId,
-          name,
-          voteType,
-          updatedBy: user.id,
-          options:
-            voteType === VOTING_TYPES.SECRET_BALLOT.key
-              ? [...FIXED_OPTIONS, ...options]
-              : options,
-        }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to create voting event');
-      }
-
-      const event: VotingEventWithRelations = await res.json();
-      setPendingEvent(event);
-      await onVotingEventsMutated?.();
-      setMeetingId('');
-      setName('');
-      setOptions([]);
-    } catch (err) {
-      setCreateError(err instanceof Error ? err.message : 'Unknown error');
-    } finally {
-      setSubmitting(false);
-    }
-  };
+  if (!user || user.role !== 'EBOARD') return null;
 
   const handleEnd = async (votingEventId: string) => {
     setEndErrors((prev) => ({ ...prev, [votingEventId]: null }));
-
     try {
       const res = await fetch(`/api/voting-event/${votingEventId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ end: true, updatedBy: user.id }),
       });
-
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         throw new Error(data.error || 'Failed to end voting event');
-      }
-
-      if (pendingEvent?.votingEventId === votingEventId) {
-        setPendingEvent(null);
       }
       await refreshActiveEvent();
       await onVotingEventsMutated?.();
@@ -259,193 +80,40 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
     <div className='mt-6 bg-white rounded-2xl shadow-lg p-6 border border-gray-100'>
       <div className='flex items-center justify-between mb-4'>
         <h2 className='text-lg font-semibold text-gray-900'>Voting Controls</h2>
-        {displayedActiveEvents.length > 0 && (
+        {activeEvents.length > 0 && (
           <span className='inline-flex items-center gap-1.5 rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-700'>
             <span className='h-1.5 w-1.5 rounded-full bg-green-500' />
-            {displayedActiveEvents.length === 1
+            {activeEvents.length === 1
               ? 'Vote In Progress'
-              : `${displayedActiveEvents.length} Votes In Progress`}
+              : `${activeEvents.length} Votes In Progress`}
           </span>
         )}
       </div>
 
-      {activeEventLoading && displayedActiveEvents.length === 0 && (
+      {activeEventLoading && (
         <p className='mb-4 text-sm text-gray-500'>Checking for active votes…</p>
       )}
 
-      {displayedActiveEvents.length > 0 && (
+      {!activeEventLoading && activeEvents.length > 0 && (
         <div className='space-y-2'>
-          {displayedActiveEvents.map((event) => {
-            const meeting = event.meeting;
-            const voteTypeLabel =
-              Object.values(VOTING_TYPES).find((t) => t.key === event.voteType)
-                ?.value ?? event.voteType;
-            const endError = endErrors[event.votingEventId];
-            const voteCounts = getVoteCounts(event);
-            const totalVotes = Object.values(voteCounts).reduce(
-              (sum, n) => sum + n,
-              0,
-            );
-
-            return (
-              <div
-                key={event.votingEventId}
-                className='rounded-xl border border-gray-100 bg-gray-50 p-5 text-sm'
-              >
-                <div className='flex items-start justify-between gap-2'>
-                  <div className='min-w-0'>
-                    <div className='font-medium text-gray-900'>
-                      {event.name}
-                    </div>
-                    <div className='text-sm text-gray-400 mt-0.5'>
-                      {[
-                        voteTypeLabel,
-                        meeting && `${meeting.date} · ${meeting.name}`,
-                      ]
-                        .filter(Boolean)
-                        .join(' · ')}
-                    </div>
-                  </div>
-                  <button
-                    type='button'
-                    onClick={() => handleEnd(event.votingEventId)}
-                    className='shrink-0 px-4 py-1 bg-gray-800 text-white rounded-lg text-sm font-medium hover:bg-gray-900 disabled:opacity-60 disabled:cursor-not-allowed'
-                  >
-                    Close Vote
-                  </button>
-                </div>
-                <VoteBreakdown
-                  event={event}
-                  eligible={eligibleCounts[event.meetingId] ?? 0}
-                  voteCounts={voteCounts}
-                  totalVotes={totalVotes}
-                />
-                {endError && (
-                  <p className='mt-2 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2'>
-                    {endError}
-                  </p>
-                )}
-              </div>
-            );
-          })}
+          {activeEvents.map((event) => (
+            <ActiveVoteCard
+              key={event.votingEventId}
+              event={event}
+              eligible={eligibleCounts[event.meetingId] ?? 0}
+              onEnd={handleEnd}
+              endError={endErrors[event.votingEventId]}
+            />
+          ))}
         </div>
       )}
 
-      {!activeEventLoading && displayedActiveEvents.length === 0 && (
-        <form onSubmit={handleCreate} className='space-y-4'>
-          <div>
-            <label className='block text-sm font-medium text-gray-700 mb-1'>
-              Meeting
-            </label>
-            <select
-              value={meetingId}
-              onChange={(e) => setMeetingId(e.target.value)}
-              className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E]'
-            >
-              <option value=''>Select a meeting</option>
-              {meetingsForDropdown.map((m) => (
-                <option key={m.meetingId} value={m.meetingId}>
-                  {m.date} — {m.name}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div>
-            <label className='block text-sm font-medium text-gray-700 mb-1'>
-              Question / Name
-            </label>
-            <input
-              type='text'
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E]'
-              placeholder='Enter the vote question or title'
-            />
-          </div>
-
-          <div>
-            <label className='block text-sm font-medium text-gray-700 mb-1'>
-              Vote Type
-            </label>
-            <select
-              value={voteType}
-              onChange={(e) => setVoteType(e.target.value)}
-              className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E]'
-            >
-              {Object.values(VOTING_TYPES).map((type) => (
-                <option key={type.key} value={type.key}>
-                  {type.value}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {voteType === VOTING_TYPES.SECRET_BALLOT.key && (
-            <div>
-              <label className='block text-sm font-medium text-gray-700 mb-1'>
-                Options
-              </label>
-              <div className='space-y-2'>
-                {FIXED_OPTIONS.map((fixed) => (
-                  <div key={fixed} className='relative'>
-                    <input
-                      type='text'
-                      value={fixed}
-                      readOnly
-                      disabled
-                      className='w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-600'
-                    />
-                  </div>
-                ))}
-
-                {options.map((option, index) => (
-                  <div key={index} className='relative'>
-                    <input
-                      type='text'
-                      value={option}
-                      onChange={(e) => {
-                        const newOptions = [...options];
-                        newOptions[index] = e.target.value;
-                        setOptions(newOptions);
-                      }}
-                      className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E] pr-8'
-                    />
-                    <X
-                      onClick={() => removeOption(index)}
-                      className='absolute right-2 top-1/2 -translate-y-1/2 text-red-500 text-sm hover:bg-red-50 rounded px-1'
-                    />
-                  </div>
-                ))}
-              </div>
-              <div className='flex justify-end mt-2'>
-                <button
-                  type='button'
-                  onClick={addOption}
-                  className='text-sm font-medium hover:underline'
-                >
-                  + Add Option
-                </button>
-              </div>
-            </div>
-          )}
-
-          {createError && (
-            <p className='text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2'>
-              {createError}
-            </p>
-          )}
-
-          <div className='pt-2'>
-            <button
-              type='submit'
-              disabled={submitting}
-              className='px-4 py-2 bg-[#C8102E] text-white rounded-lg text-sm font-medium hover:bg-[#A8102E] disabled:opacity-60 disabled:cursor-not-allowed'
-            >
-              {submitting ? 'Starting…' : 'Create & Start Voting Event'}
-            </button>
-          </div>
-        </form>
+      {!activeEventLoading && activeEvents.length === 0 && (
+        <CreateVoteForm
+          meetings={meetings}
+          userId={user.id}
+          onCreated={refreshActiveEvent}
+        />
       )}
     </div>
   );

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -5,6 +5,15 @@ import { useActiveVotingEvent } from '@/hooks/useActiveVotingEvent';
 import ActiveVoteCard from './ActiveVoteCard';
 import CreateVoteForm from './CreateVoteForm';
 
+async function fetchEligibleCount(
+  meetingId: string,
+): Promise<[string, number] | null> {
+  const res = await fetch(`/api/attendance/meeting/${meetingId}`);
+  if (!res.ok) return null;
+  const records: { status: string }[] = await res.json();
+  return [meetingId, records.filter((r) => r.status === 'PRESENT').length];
+}
+
 interface VotingAdminPanelProps {
   meetings: MeetingApiData[];
   onVotingEventsMutated?: () => void | Promise<void>;
@@ -38,25 +47,16 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
     ].filter((mid) => !(mid in eligibleCounts));
     if (unfetchedIds.length === 0) return;
 
-    (async () => {
-      const settled = await Promise.allSettled(
-        unfetchedIds.map(async (mid) => {
-          const res = await fetch(`/api/attendance/meeting/${mid}`);
-          if (!res.ok) throw new Error();
-          const records: { status: string }[] = await res.json();
-          return [
-            mid,
-            records.filter((r) => r.status === 'PRESENT').length,
-          ] as [string, number];
-        }),
-      );
+    Promise.allSettled(unfetchedIds.map(fetchEligibleCount)).then((settled) => {
       const updates = Object.fromEntries(
-        settled.flatMap((r) => (r.status === 'fulfilled' ? [r.value] : [])),
+        settled.flatMap((r) =>
+          r.status === 'fulfilled' && r.value ? [r.value] : [],
+        ),
       );
       if (Object.keys(updates).length > 0) {
         setEligibleCounts((prev) => ({ ...prev, ...updates }));
       }
-    })();
+    });
   }, [activeEvents, eligibleCounts]);
 
   if (!user || user.role !== 'EBOARD') return null;

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -1,53 +1,117 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { MeetingApiData, VotingEventWithRelations } from '@/types';
 import { getVoteCounts } from '@/utils/voting_utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { useActiveVotingEvent } from '@/hooks/useActiveVotingEvent';
 import { X } from 'lucide-react';
-import { VOTING_TYPES } from '@/utils/consts';
+import { VOTING_TYPES, YES_NO_OPTIONS } from '@/utils/consts';
 
 const FIXED_OPTIONS = ['Abstain', 'No Confidence'] as const;
 
 const optionRank = (o: string) =>
   o === 'Abstain' ? 2 : o === 'No Confidence' ? 1 : 0;
 
+const optionColors = new Map([
+  ['Yes', '#bbf7d0'],
+  ['No', '#fecaca'],
+  ['Abstain', '#e5e7eb'],
+  ['No Confidence', '#fde68a'],
+]);
+const FALLBACK_COLORS = ['#bfdbfe', '#ddd6fe', '#fbcfe8', '#99f6e4', '#fed7aa'];
+
+const getOptionColor = (opt: string, idx: number): string =>
+  optionColors.get(opt) ?? FALLBACK_COLORS[idx % FALLBACK_COLORS.length];
+
+// ─── VoteBreakdown ────────────────────────────────────────────────────────────
+
+interface VoteBreakdownProps {
+  event: VotingEventWithRelations;
+  eligible: number;
+  voteCounts: Record<string, number>;
+  totalVotes: number;
+}
+
+const VoteBreakdown: React.FC<VoteBreakdownProps> = ({
+  event,
+  eligible,
+  voteCounts,
+  totalVotes,
+}) => {
+  const opts =
+    event.options.length > 0
+      ? [...event.options].sort((a, b) => optionRank(a) - optionRank(b))
+      : Object.values(YES_NO_OPTIONS);
+
+  if (opts.length === 0) return null;
+
+  // Bar widths are out of eligible (gray remainder = not yet voted).
+  // Falls back to totalVotes if eligible is unavailable or stale.
+  const barDenom = Math.max(eligible, totalVotes);
+
+  return (
+    <div className='mt-4 pt-4 border-t border-gray-200'>
+      <p className='font-medium text-gray-900 mb-3'>
+        Total Votes Cast: {totalVotes}/{eligible > 0 ? eligible : '—'}
+        {eligible > 0 && (
+          <span className='ml-1'>
+            ({Math.round((Math.min(totalVotes, eligible) / eligible) * 100)}%)
+          </span>
+        )}
+      </p>
+      <div className='h-10 w-full rounded-xl overflow-hidden flex bg-gray-200'>
+        {opts.map((opt, idx) => {
+          const count = voteCounts[opt] ?? 0;
+          const barPct = barDenom > 0 ? (count / barDenom) * 100 : 0;
+          const labelPct =
+            totalVotes > 0 ? Math.round((count / totalVotes) * 100) : 0;
+          return (
+            <div
+              key={opt}
+              className='h-full flex items-center justify-center overflow-hidden transition-all duration-500'
+              style={{
+                width: `${barPct}%`,
+                backgroundColor: getOptionColor(opt, idx),
+              }}
+              title={`${opt}: ${count} (${labelPct}%)`}
+            >
+              {barPct >= 8 && (
+                <span className='text-sm font-medium text-gray-800 whitespace-nowrap px-2 truncate'>
+                  {opt} · {count} · {labelPct}%
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+// ─── VotingAdminPanel ─────────────────────────────────────────────────────────
+
 interface VotingAdminPanelProps {
   meetings: MeetingApiData[];
-  onEventCreated?: (event: VotingEventWithRelations) => void;
   onVotingEventsMutated?: () => void | Promise<void>;
 }
 
 const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
   meetings,
-  onEventCreated,
   onVotingEventsMutated,
 }) => {
-  // ─── States ────────────────────────────────────────────────────────────────
   const { user } = useAuth();
   const [meetingId, setMeetingId] = useState<string>('');
   const [name, setName] = useState<string>('');
   const [voteType, setVoteType] = useState<string>(VOTING_TYPES.ROLL_CALL.key);
   const [submitting, setSubmitting] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
-  const [endErrors, setEndErrors] = useState<Record<string, string>>({});
+  const [endErrors, setEndErrors] = useState<Record<string, string | null>>({});
   const [pendingEvent, setPendingEvent] =
     useState<VotingEventWithRelations | null>(null);
   const [options, setOptions] = useState<string[]>([]);
+  const [eligibleCounts, setEligibleCounts] = useState<Record<string, number>>(
+    {},
+  );
 
-  // ─── Functions ─────────────────────────────────────────────────────────────
-  const addOption = () => {
-    setOptions((prev) => {
-      const count = prev.filter((o) => o.startsWith('Option')).length;
-      const newOption = count === 0 ? 'Option' : `Option ${count + 1}`;
-      return [...prev, newOption];
-    });
-  };
-
-  const removeOption = (option: string) => {
-    setOptions((prev) => prev.filter((o) => o !== option));
-  };
-
-  // ─── Hooks ─────────────────────────────────────────────────────────────────
   const {
     activeEvents,
     loading: activeEventLoading,
@@ -78,13 +142,46 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
       if (!/^\d{4}-\d{2}-\d{2}$/.test(meetingDateStr)) return true;
       return meetingDateStr >= todayStr;
     });
-    if (upcoming.length > 0) return upcoming;
-    return meetings;
+    return upcoming.length > 0 ? upcoming : meetings;
   }, [meetings]);
+
+  // Fetch eligible voter counts for any meeting not yet loaded.
+  // eligibleCounts in deps is intentional: after each fetch completes the
+  // effect re-runs, the filter finds no new IDs, and exits immediately.
+  useEffect(() => {
+    const unfetchedIds = [
+      ...new Set(displayedActiveEvents.map((e) => e.meetingId)),
+    ].filter((mid) => !(mid in eligibleCounts));
+
+    if (unfetchedIds.length === 0) return;
+
+    unfetchedIds.forEach(async (mid) => {
+      try {
+        const res = await fetch(`/api/attendance/meeting/${mid}`);
+        if (!res.ok) return;
+        const records: { status: string }[] = await res.json();
+        const count = records.filter((r) => r.status === 'PRESENT').length;
+        setEligibleCounts((prev) => ({ ...prev, [mid]: count }));
+      } catch {
+        // eligible count is best-effort; silently ignore
+      }
+    });
+  }, [displayedActiveEvents, eligibleCounts]);
 
   if (!user || user.role !== 'EBOARD') {
     return null;
   }
+
+  const addOption = () => {
+    setOptions((prev) => {
+      const count = prev.filter((o) => o.startsWith('Option')).length;
+      return [...prev, count === 0 ? 'Option' : `Option ${count + 1}`];
+    });
+  };
+
+  const removeOption = (index: number) => {
+    setOptions((prev) => prev.filter((_, i) => i !== index));
+  };
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -119,9 +216,6 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
 
       const event: VotingEventWithRelations = await res.json();
       setPendingEvent(event);
-      if (onEventCreated) {
-        onEventCreated(event);
-      }
       await onVotingEventsMutated?.();
       setMeetingId('');
       setName('');
@@ -134,13 +228,13 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
   };
 
   const handleEnd = async (votingEventId: string) => {
-    setEndErrors((prev) => ({ ...prev, [votingEventId]: '' }));
+    setEndErrors((prev) => ({ ...prev, [votingEventId]: null }));
 
     try {
       const res = await fetch(`/api/voting-event/${votingEventId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ end: true, updatedBy: user?.id }),
+        body: JSON.stringify({ end: true, updatedBy: user.id }),
       });
 
       if (!res.ok) {
@@ -200,17 +294,17 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
               >
                 <div className='flex items-start justify-between gap-2'>
                   <div className='min-w-0'>
-                    <span className='font-medium text-gray-900'>
+                    <div className='font-medium text-gray-900'>
                       {event.name}
-                    </span>
-                    <span className='ml-2 text-gray-400'>
+                    </div>
+                    <div className='text-sm text-gray-400 mt-0.5'>
                       {[
                         voteTypeLabel,
                         meeting && `${meeting.date} · ${meeting.name}`,
                       ]
                         .filter(Boolean)
                         .join(' · ')}
-                    </span>
+                    </div>
                   </div>
                   <button
                     type='button'
@@ -220,52 +314,12 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
                     Close Vote
                   </button>
                 </div>
-                {(() => {
-                  const opts =
-                    event.options.length > 0
-                      ? [...event.options].sort(
-                          (a, b) => optionRank(a) - optionRank(b),
-                        )
-                      : Object.keys(voteCounts);
-                  if (opts.length === 0) return null;
-                  return (
-                    <div className='mt-4 pt-4 border-t border-gray-200'>
-                      <p className='text-xs font-medium text-gray-500 mb-3'>
-                        {totalVotes} {totalVotes === 1 ? 'vote' : 'votes'} cast
-                      </p>
-                      <div className='space-y-2.5'>
-                        {opts.map((opt) => {
-                          const count = voteCounts[opt] ?? 0;
-                          const pct =
-                            totalVotes > 0
-                              ? Math.round((count / totalVotes) * 100)
-                              : 0;
-                          return (
-                            <div key={opt}>
-                              <div className='flex items-center justify-between mb-1'>
-                                <span className='text-xs text-gray-600'>
-                                  {opt}
-                                </span>
-                                <span className='text-xs font-semibold text-gray-900'>
-                                  {count}{' '}
-                                  <span className='font-normal text-gray-400'>
-                                    {pct}%
-                                  </span>
-                                </span>
-                              </div>
-                              <div className='h-2 w-full rounded-full bg-gray-200'>
-                                <div
-                                  className='h-2 rounded-full bg-[#C8102E] transition-all duration-500'
-                                  style={{ width: `${pct}%` }}
-                                />
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })()}
+                <VoteBreakdown
+                  event={event}
+                  eligible={eligibleCounts[event.meetingId] ?? 0}
+                  voteCounts={voteCounts}
+                  totalVotes={totalVotes}
+                />
                 {endError && (
                   <p className='mt-2 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2'>
                     {endError}
@@ -358,7 +412,7 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
                       className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#C8102E] pr-8'
                     />
                     <X
-                      onClick={() => removeOption(option)}
+                      onClick={() => removeOption(index)}
                       className='absolute right-2 top-1/2 -translate-y-1/2 text-red-500 text-sm hover:bg-red-50 rounded px-1'
                     />
                   </div>

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -36,20 +36,27 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
     const unfetchedIds = [
       ...new Set(activeEvents.map((e) => e.meetingId)),
     ].filter((mid) => !(mid in eligibleCounts));
-
     if (unfetchedIds.length === 0) return;
 
-    unfetchedIds.forEach(async (mid) => {
-      try {
-        const res = await fetch(`/api/attendance/meeting/${mid}`);
-        if (!res.ok) return;
-        const records: { status: string }[] = await res.json();
-        const count = records.filter((r) => r.status === 'PRESENT').length;
-        setEligibleCounts((prev) => ({ ...prev, [mid]: count }));
-      } catch {
-        // eligible count is best-effort; silently ignore
+    (async () => {
+      const settled = await Promise.allSettled(
+        unfetchedIds.map(async (mid) => {
+          const res = await fetch(`/api/attendance/meeting/${mid}`);
+          if (!res.ok) throw new Error();
+          const records: { status: string }[] = await res.json();
+          return [
+            mid,
+            records.filter((r) => r.status === 'PRESENT').length,
+          ] as [string, number];
+        }),
+      );
+      const updates = Object.fromEntries(
+        settled.flatMap((r) => (r.status === 'fulfilled' ? [r.value] : [])),
+      );
+      if (Object.keys(updates).length > 0) {
+        setEligibleCounts((prev) => ({ ...prev, ...updates }));
       }
-    });
+    })();
   }, [activeEvents, eligibleCounts]);
 
   if (!user || user.role !== 'EBOARD') return null;
@@ -63,15 +70,18 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
         body: JSON.stringify({ end: true, updatedBy: user.id }),
       });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to end voting event');
+        setEndErrors((prev) => ({
+          ...prev,
+          [votingEventId]: 'Failed to end voting event.',
+        }));
+        return;
       }
       await refreshActiveEvent();
       await onVotingEventsMutated?.();
-    } catch (err) {
+    } catch {
       setEndErrors((prev) => ({
         ...prev,
-        [votingEventId]: err instanceof Error ? err.message : 'Unknown error',
+        [votingEventId]: 'Failed to end voting event.',
       }));
     }
   };

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -1,18 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { MeetingApiData } from '@/types';
 import { useAuth } from '@/contexts/AuthContext';
 import { useActiveVotingEvent } from '@/hooks/useActiveVotingEvent';
 import ActiveVoteCard from './ActiveVoteCard';
 import CreateVoteForm from './CreateVoteForm';
-
-async function fetchEligibleCount(
-  meetingId: string,
-): Promise<[string, number] | null> {
-  const res = await fetch(`/api/attendance/meeting/${meetingId}`);
-  if (!res.ok) return null;
-  const records: { status: string }[] = await res.json();
-  return [meetingId, records.filter((r) => r.status === 'PRESENT').length];
-}
 
 interface VotingAdminPanelProps {
   meetings: MeetingApiData[];
@@ -24,13 +15,7 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
   onVotingEventsMutated,
 }) => {
   const { user } = useAuth();
-
-  // Per-event end errors
   const [endErrors, setEndErrors] = useState<Record<string, string | null>>({});
-  // Eligible voter counts keyed by meetingId
-  const [eligibleCounts, setEligibleCounts] = useState<Record<string, number>>(
-    {},
-  );
 
   const {
     activeEvents,
@@ -38,28 +23,10 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
     refresh: refreshActiveEvent,
   } = useActiveVotingEvent();
 
-  // Fetch eligible voter counts for any meeting not yet loaded.
-  // eligibleCounts in deps is intentional: after each fetch completes the
-  // effect re-runs, the filter finds no new IDs, and exits immediately.
-  useEffect(() => {
-    const unfetchedIds = [
-      ...new Set(activeEvents.map((e) => e.meetingId)),
-    ].filter((mid) => !(mid in eligibleCounts));
-    if (unfetchedIds.length === 0) return;
-
-    Promise.allSettled(unfetchedIds.map(fetchEligibleCount)).then((settled) => {
-      const updates = Object.fromEntries(
-        settled.flatMap((r) =>
-          r.status === 'fulfilled' && r.value ? [r.value] : [],
-        ),
-      );
-      if (Object.keys(updates).length > 0) {
-        setEligibleCounts((prev) => ({ ...prev, ...updates }));
-      }
-    });
-  }, [activeEvents, eligibleCounts]);
-
   if (!user || user.role !== 'EBOARD') return null;
+
+  const meetingEligibleCount = (meetingId: string) =>
+    meetings.find((m) => m.meetingId === meetingId)?.eligibleCount ?? 0;
 
   const handleEnd = async (votingEventId: string) => {
     setEndErrors((prev) => ({ ...prev, [votingEventId]: null }));
@@ -110,7 +77,7 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
             <ActiveVoteCard
               key={event.votingEventId}
               event={event}
-              eligible={eligibleCounts[event.meetingId] ?? 0}
+              eligible={meetingEligibleCount(event.meetingId)}
               onEnd={handleEnd}
               endError={endErrors[event.votingEventId]}
             />

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -220,30 +220,52 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
                     Close Vote
                   </button>
                 </div>
-                <div className='mt-4 pt-4 border-t border-gray-200 flex items-center gap-2 flex-wrap'>
-                  <span className='font-semibold text-gray-900'>
-                    {totalVotes} total
-                  </span>
-                  {(() => {
-                    const opts =
-                      event.voteType === VOTING_TYPES.SECRET_BALLOT.key
-                        ? [...event.options].sort(
-                            (a, b) => optionRank(a) - optionRank(b),
-                          )
-                        : Object.keys(voteCounts);
-                    return opts.map((opt) => (
-                      <span
-                        key={opt}
-                        className='inline-flex items-center gap-1 rounded-md bg-gray-200 px-2 py-0.5 text-xs text-gray-600'
-                      >
-                        {opt}
-                        <span className='font-semibold text-gray-900'>
-                          {voteCounts[opt] ?? 0}
-                        </span>
-                      </span>
-                    ));
-                  })()}
-                </div>
+                {(() => {
+                  const opts =
+                    event.options.length > 0
+                      ? [...event.options].sort(
+                          (a, b) => optionRank(a) - optionRank(b),
+                        )
+                      : Object.keys(voteCounts);
+                  if (opts.length === 0) return null;
+                  return (
+                    <div className='mt-4 pt-4 border-t border-gray-200'>
+                      <p className='text-xs font-medium text-gray-500 mb-3'>
+                        {totalVotes} {totalVotes === 1 ? 'vote' : 'votes'} cast
+                      </p>
+                      <div className='space-y-2.5'>
+                        {opts.map((opt) => {
+                          const count = voteCounts[opt] ?? 0;
+                          const pct =
+                            totalVotes > 0
+                              ? Math.round((count / totalVotes) * 100)
+                              : 0;
+                          return (
+                            <div key={opt}>
+                              <div className='flex items-center justify-between mb-1'>
+                                <span className='text-xs text-gray-600'>
+                                  {opt}
+                                </span>
+                                <span className='text-xs font-semibold text-gray-900'>
+                                  {count}{' '}
+                                  <span className='font-normal text-gray-400'>
+                                    {pct}%
+                                  </span>
+                                </span>
+                              </div>
+                              <div className='h-2 w-full rounded-full bg-gray-200'>
+                                <div
+                                  className='h-2 rounded-full bg-[#C8102E] transition-all duration-500'
+                                  style={{ width: `${pct}%` }}
+                                />
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })()}
                 {endError && (
                   <p className='mt-2 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2'>
                     {endError}

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -227,38 +227,43 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
                       {voteTypeLabel}
                     </span>
                   </div>
-                  {event.voteType === VOTING_TYPES.SECRET_BALLOT.key &&
-                    event.options.length > 0 && (
-                      <div className='flex items-start gap-2'>
-                        <span className='w-20 shrink-0 text-gray-400'>
-                          Options
-                        </span>
-                        <div className='flex flex-wrap gap-1'>
-                          {[...event.options]
-                            .sort((a, b) => optionRank(a) - optionRank(b))
-                            .map((opt) => (
-                              <span
-                                key={opt}
-                                className='rounded-md bg-gray-200 px-2 py-0.5 text-xs font-medium text-gray-700'
-                              >
-                                {opt}
-                              </span>
-                            ))}
-                        </div>
-                      </div>
-                    )}
-                  <div className='flex items-baseline gap-2'>
+                  <div className='flex items-start gap-2'>
                     <span className='w-20 shrink-0 text-gray-400'>Votes</span>
-                    <span className='font-medium text-gray-900'>
-                      {totalVotes}
-                      {totalVotes > 0 && (
-                        <span className='ml-2 font-normal text-gray-500'>
-                          {Object.entries(voteCounts)
-                            .map(([k, v]) => `${k}: ${v}`)
-                            .join(' · ')}
-                        </span>
-                      )}
-                    </span>
+                    <div className='flex-1'>
+                      <div className='mb-1 font-medium text-gray-900'>
+                        {totalVotes} total
+                      </div>
+                      {(() => {
+                        const rows =
+                          event.voteType === VOTING_TYPES.SECRET_BALLOT.key
+                            ? [...event.options].sort(
+                                (a, b) => optionRank(a) - optionRank(b),
+                              )
+                            : Object.keys(voteCounts);
+                        if (rows.length === 0) return null;
+                        return (
+                          <table className='w-full text-xs border-separate border-spacing-0 rounded-lg overflow-hidden border border-gray-200'>
+                            <tbody>
+                              {rows.map((opt, i) => (
+                                <tr
+                                  key={opt}
+                                  className={
+                                    i % 2 === 0 ? 'bg-white' : 'bg-gray-50'
+                                  }
+                                >
+                                  <td className='px-3 py-1.5 text-gray-600'>
+                                    {opt}
+                                  </td>
+                                  <td className='px-3 py-1.5 text-right font-semibold text-gray-900 w-12'>
+                                    {voteCounts[opt] ?? 0}
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        );
+                      })()}
+                    </div>
                   </div>
                 </div>
                 {endError && (

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -227,43 +227,30 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
                       {voteTypeLabel}
                     </span>
                   </div>
-                  <div className='flex items-start gap-2'>
+                  <div className='flex items-center gap-2 flex-wrap'>
                     <span className='w-20 shrink-0 text-gray-400'>Votes</span>
-                    <div className='flex-1'>
-                      <div className='mb-1 font-medium text-gray-900'>
-                        {totalVotes} total
-                      </div>
-                      {(() => {
-                        const rows =
-                          event.voteType === VOTING_TYPES.SECRET_BALLOT.key
-                            ? [...event.options].sort(
-                                (a, b) => optionRank(a) - optionRank(b),
-                              )
-                            : Object.keys(voteCounts);
-                        if (rows.length === 0) return null;
-                        return (
-                          <table className='w-full text-xs border-separate border-spacing-0 rounded-lg overflow-hidden border border-gray-200'>
-                            <tbody>
-                              {rows.map((opt, i) => (
-                                <tr
-                                  key={opt}
-                                  className={
-                                    i % 2 === 0 ? 'bg-white' : 'bg-gray-50'
-                                  }
-                                >
-                                  <td className='px-3 py-1.5 text-gray-600'>
-                                    {opt}
-                                  </td>
-                                  <td className='px-3 py-1.5 text-right font-semibold text-gray-900 w-12'>
-                                    {voteCounts[opt] ?? 0}
-                                  </td>
-                                </tr>
-                              ))}
-                            </tbody>
-                          </table>
-                        );
-                      })()}
-                    </div>
+                    <span className='font-semibold text-gray-900'>
+                      {totalVotes} total
+                    </span>
+                    {(() => {
+                      const opts =
+                        event.voteType === VOTING_TYPES.SECRET_BALLOT.key
+                          ? [...event.options].sort(
+                              (a, b) => optionRank(a) - optionRank(b),
+                            )
+                          : Object.keys(voteCounts);
+                      return opts.map((opt) => (
+                        <span
+                          key={opt}
+                          className='inline-flex items-center gap-1 rounded-md bg-gray-200 px-2 py-0.5 text-xs text-gray-600'
+                        >
+                          {opt}
+                          <span className='font-semibold text-gray-900'>
+                            {voteCounts[opt] ?? 0}
+                          </span>
+                        </span>
+                      ));
+                    })()}
                   </div>
                 </div>
                 {endError && (

--- a/attendance-manager/src/components/voting/VotingAdminPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingAdminPanel.tsx
@@ -36,13 +36,7 @@ const VotingAdminPanel: React.FC<VotingAdminPanelProps> = ({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ end: true, updatedBy: user.id }),
       });
-      if (!res.ok) {
-        setEndErrors((prev) => ({
-          ...prev,
-          [votingEventId]: 'Failed to end voting event.',
-        }));
-        return;
-      }
+      if (!res.ok) throw new Error();
       await refreshActiveEvent();
       await onVotingEventsMutated?.();
     } catch {

--- a/attendance-manager/src/components/voting/VotingPage.tsx
+++ b/attendance-manager/src/components/voting/VotingPage.tsx
@@ -18,7 +18,7 @@ const VotingPage: React.FC = () => {
     setEventsLoading(true);
     try {
       const [meetingsRes, eventsRes] = await Promise.all([
-        fetch('/api/meeting'),
+        fetch('/api/meeting/upcoming'),
         fetch('/api/voting-event'),
       ]);
 

--- a/attendance-manager/src/components/voting/VotingPage.tsx
+++ b/attendance-manager/src/components/voting/VotingPage.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { MeetingApiData, VotingEventWithRelations } from '@/types';
 import VotingAdminPanel from '@/components/voting/VotingAdminPanel';
-import OngoingVotingPanel from '@/components/voting/OngoingVotingPanel';
 import VotingResultsPanel from '@/components/voting/VotingResultsPanel';
 import DeleteVotingModal from '@/components/voting/DeleteVotingModal';
 
@@ -12,7 +11,6 @@ const VotingPage: React.FC = () => {
   const [deleteEvent, setDeleteEvent] =
     useState<VotingEventWithRelations | null>(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
-  const [ongoingRefreshTrigger, setOngoingRefreshTrigger] = useState(0);
 
   const loadMeetingsAndEvents = useCallback(async () => {
     setEventsLoading(true);
@@ -31,7 +29,6 @@ const VotingPage: React.FC = () => {
         const eventsData: VotingEventWithRelations[] = await eventsRes.json();
         setEvents(eventsData);
       }
-      setOngoingRefreshTrigger((n) => n + 1);
     } catch (error) {
       globalThis.console?.error('Failed to load meetings and events', error);
     } finally {
@@ -81,7 +78,6 @@ const VotingPage: React.FC = () => {
         meetings={meetings}
         onVotingEventsMutated={loadMeetingsAndEvents}
       />
-      <OngoingVotingPanel refreshTrigger={ongoingRefreshTrigger} />
       <VotingResultsPanel
         events={events}
         loading={eventsLoading}

--- a/attendance-manager/src/components/voting/VotingResultsModal.tsx
+++ b/attendance-manager/src/components/voting/VotingResultsModal.tsx
@@ -75,7 +75,7 @@ const VotingResultsModal: React.FC<VotingResultsModalProps> = ({
             </div>
           )}
 
-          <div className='flex space-x-3 pt-6 border-t border-gray-200 mt-6'>
+          <div className='flex pt-6 border-t border-gray-200 mt-6'>
             <button
               type='button'
               onClick={() => {

--- a/attendance-manager/src/components/voting/VotingResultsPanel.tsx
+++ b/attendance-manager/src/components/voting/VotingResultsPanel.tsx
@@ -88,17 +88,13 @@ const VotingResultsPanel: React.FC<VotingResultsPanelProps> = ({
                     }}
                   >
                     <td className='py-2 px-3 align-top'>
-                      <div className='flex items-start justify-between'>
-                        <div>
-                          <div className='text-gray-900 font-medium'>
-                            {event.meeting?.name ?? 'Unknown meeting'}
-                          </div>
-                          <div className='text-xs text-gray-500'>
-                            {event.meeting?.date
-                              ? event.meeting.date
-                              : new Date(event.createdAt).toLocaleDateString()}
-                          </div>
-                        </div>
+                      <div className='text-gray-900 font-medium'>
+                        {event.meeting?.name ?? 'Unknown meeting'}
+                      </div>
+                      <div className='text-xs text-gray-500'>
+                        {event.meeting?.date
+                          ? event.meeting.date
+                          : new Date(event.createdAt).toLocaleDateString()}
                       </div>
                     </td>
                     <td className='py-3 px-4 align-top'>
@@ -161,7 +157,7 @@ const VotingResultsPanel: React.FC<VotingResultsPanelProps> = ({
                         </div>
                       )}
                       {/* Delete button for past events */}
-                      <div className='ml-1 flex-shrink-0'>
+                      <div className='ml-1'>
                         <button
                           onClick={(e) => {
                             e.stopPropagation();

--- a/attendance-manager/src/hooks/useActiveVotingEvent.ts
+++ b/attendance-manager/src/hooks/useActiveVotingEvent.ts
@@ -6,6 +6,7 @@ interface UseActiveVotingEventOptions {
 }
 
 interface UseActiveVotingEventResult {
+  activeEvents: VotingEventWithRelations[];
   activeEvent: VotingEventWithRelations | null;
   loading: boolean;
   error: string | null;
@@ -13,20 +14,20 @@ interface UseActiveVotingEventResult {
 }
 
 /**
- * Polls the backend for the currently active voting event
- * "active" is defined as the most recently created VotingEvent
- * with deletedAt === null and endedAt === null
+ * Polls the backend for currently active voting events.
+ * "active" is defined as VotingEvents with deletedAt === null and endedAt === null.
  */
 export function useActiveVotingEvent(
   options: UseActiveVotingEventOptions = {},
 ): UseActiveVotingEventResult {
   const { pollIntervalMs = 3000 } = options;
-  const [activeEvent, setActiveEvent] =
-    useState<VotingEventWithRelations | null>(null);
+  const [activeEvents, setActiveEvents] = useState<VotingEventWithRelations[]>(
+    [],
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchActiveEvent = useCallback(async () => {
+  const fetchActiveEvents = useCallback(async () => {
     try {
       setError(null);
       const res = await fetch('/api/voting-event/active');
@@ -35,16 +36,11 @@ export function useActiveVotingEvent(
       }
       const events: VotingEventWithRelations[] = await res.json();
 
-      if (events.length === 0) {
-        setActiveEvent(null);
-        return;
-      }
-
       const sorted = [...events].sort(
         (a, b) =>
           new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
       );
-      setActiveEvent(sorted[0]);
+      setActiveEvents(sorted);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       setError(message);
@@ -54,19 +50,20 @@ export function useActiveVotingEvent(
   }, []);
 
   useEffect(() => {
-    fetchActiveEvent();
+    fetchActiveEvents();
 
-    const id = window.setInterval(fetchActiveEvent, pollIntervalMs);
+    const id = window.setInterval(fetchActiveEvents, pollIntervalMs);
 
     return () => {
       window.clearInterval(id);
     };
-  }, [fetchActiveEvent, pollIntervalMs]);
+  }, [fetchActiveEvents, pollIntervalMs]);
 
   return {
-    activeEvent,
+    activeEvents,
+    activeEvent: activeEvents[0] ?? null,
     loading,
     error,
-    refresh: fetchActiveEvent,
+    refresh: fetchActiveEvents,
   };
 }

--- a/attendance-manager/src/hooks/useActiveVotingEvent.ts
+++ b/attendance-manager/src/hooks/useActiveVotingEvent.ts
@@ -32,7 +32,8 @@ export function useActiveVotingEvent(
       setError(null);
       const res = await fetch('/api/voting-event/active');
       if (!res.ok) {
-        throw new Error(`Failed to fetch active voting event (${res.status})`);
+        setError('Failed to load active voting events.');
+        return;
       }
       const events: VotingEventWithRelations[] = await res.json();
 
@@ -41,9 +42,8 @@ export function useActiveVotingEvent(
           new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
       );
       setActiveEvents(sorted);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      setError(message);
+    } catch {
+      setError('Failed to load active voting events.');
     } finally {
       setLoading(false);
     }

--- a/attendance-manager/src/meeting/meeting.controller.ts
+++ b/attendance-manager/src/meeting/meeting.controller.ts
@@ -8,6 +8,11 @@ export const MeetingController = {
     return NextResponse.json(meeting);
   },
 
+  async listUpcomingMeetings() {
+    const meetings = await MeetingService.getUpcomingMeetings();
+    return NextResponse.json(meetings);
+  },
+
   async listMeetingsByDate() {
     const meeting = await MeetingService.getAllMeetingByDate();
     return NextResponse.json(meeting);

--- a/attendance-manager/src/meeting/meeting.service.ts
+++ b/attendance-manager/src/meeting/meeting.service.ts
@@ -35,16 +35,33 @@ export const MeetingService = {
 
   async getUpcomingMeetings() {
     const today = new Date().toISOString().slice(0, 10);
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const include = {
+      _count: {
+        select: { attendance: { where: { status: 'PRESENT' as const } } },
+      },
+    };
+    const toResult = (m: {
+      _count: { attendance: number };
+      [key: string]: unknown;
+    }) => {
+      const { _count, ...rest } = m;
+      return { ...rest, eligibleCount: _count.attendance };
+    };
+    /* eslint-enable @typescript-eslint/naming-convention */
     const upcoming = await prisma.meeting.findMany({
       where: { deletedAt: null, date: { gte: today } },
       orderBy: { date: 'asc' },
+      include,
     });
-    if (upcoming.length > 0) return upcoming;
+    if (upcoming.length > 0) return upcoming.map(toResult);
     // Fallback: no upcoming meetings, return all so the dropdown is never empty
-    return prisma.meeting.findMany({
+    const all = await prisma.meeting.findMany({
       where: { deletedAt: null },
       orderBy: { date: 'desc' },
+      include,
     });
+    return all.map(toResult);
   },
 
   async getAllMeetingByDate() {

--- a/attendance-manager/src/meeting/meeting.service.ts
+++ b/attendance-manager/src/meeting/meeting.service.ts
@@ -33,6 +33,20 @@ export const MeetingService = {
     });
   },
 
+  async getUpcomingMeetings() {
+    const today = new Date().toISOString().slice(0, 10);
+    const upcoming = await prisma.meeting.findMany({
+      where: { deletedAt: null, date: { gte: today } },
+      orderBy: { date: 'asc' },
+    });
+    if (upcoming.length > 0) return upcoming;
+    // Fallback: no upcoming meetings, return all so the dropdown is never empty
+    return prisma.meeting.findMany({
+      where: { deletedAt: null },
+      orderBy: { date: 'desc' },
+    });
+  },
+
   async getAllMeetingByDate() {
     const meetings = await prisma.meeting.findMany({
       where: {

--- a/attendance-manager/src/meeting/meeting.service.ts
+++ b/attendance-manager/src/meeting/meeting.service.ts
@@ -35,20 +35,22 @@ export const MeetingService = {
 
   async getUpcomingMeetings() {
     const today = new Date().toISOString().slice(0, 10);
-    /* eslint-disable @typescript-eslint/naming-convention */
     const include = {
-      _count: {
-        select: { attendance: { where: { status: 'PRESENT' as const } } },
+      attendance: {
+        where: { status: 'PRESENT' as const },
+        select: { attendanceId: true },
       },
     };
-    const toResult = (m: {
-      _count: { attendance: number };
+    const toResult = ({
+      attendance,
+      ...m
+    }: {
+      attendance: unknown[];
       [key: string]: unknown;
-    }) => {
-      const { _count, ...rest } = m;
-      return { ...rest, eligibleCount: _count.attendance };
-    };
-    /* eslint-enable @typescript-eslint/naming-convention */
+    }) => ({
+      ...m,
+      eligibleCount: attendance.length,
+    });
     const upcoming = await prisma.meeting.findMany({
       where: { deletedAt: null, date: { gte: today } },
       orderBy: { date: 'asc' },

--- a/attendance-manager/src/types/index.ts
+++ b/attendance-manager/src/types/index.ts
@@ -17,6 +17,7 @@ export interface MeetingApiData {
   notes: string;
   type: MeetingType;
   attendance: AttendanceApiData[];
+  eligibleCount?: number;
 }
 
 export interface AttendanceRecord {

--- a/attendance-manager/src/utils/consts.ts
+++ b/attendance-manager/src/utils/consts.ts
@@ -1,28 +1,13 @@
-// eslint-disable-next-line
-export const VOTING_TYPES = {
-  // eslint-disable-next-line
-  ROLL_CALL: {
-    key: 'ROLL_CALL',
-    value: 'Roll Call',
-  },
-  // eslint-disable-next-line
-  SECRET_BALLOT: {
-    key: 'SECRET_BALLOT',
-    value: 'Secret Ballot',
-  },
-  // eslint-disable-next-line
-  UNANIMOUS_CONSENT: {
-    key: 'UNANIMOUS_CONSENT',
-    value: 'Unanimous Consent',
-  },
-  // eslint-disable-next-line
-  PLACARD: {
-    key: 'PLACARD',
-    value: 'Placard',
-  },
-};
-// eslint-disable-next-line
-export const YES_NO_OPTIONS = {
+export const votingTypes = {
+  rollCall: 'ROLL_CALL',
+  secretBallot: 'SECRET_BALLOT',
+  unanimousConsent: 'UNANIMOUS_CONSENT',
+  placard: 'PLACARD',
+} as const;
+
+export type VoteType = (typeof votingTypes)[keyof typeof votingTypes];
+
+export const yesNoOptions = {
   yes: 'Yes',
   no: 'No',
   abstain: 'Abstain',

--- a/attendance-manager/src/utils/consts.ts
+++ b/attendance-manager/src/utils/consts.ts
@@ -1,11 +1,18 @@
-export const votingTypes = {
-  rollCall: 'ROLL_CALL',
-  secretBallot: 'SECRET_BALLOT',
-  unanimousConsent: 'UNANIMOUS_CONSENT',
-  placard: 'PLACARD',
-} as const;
+export enum VoteType {
+  rollCall = 'ROLL_CALL',
+  secretBallot = 'SECRET_BALLOT',
+  unanimousConsent = 'UNANIMOUS_CONSENT',
+  placard = 'PLACARD',
+}
 
-export type VoteType = (typeof votingTypes)[keyof typeof votingTypes];
+export function getVoteTypeLabel(voteType: VoteType): string {
+  return {
+    [VoteType.rollCall]: 'Roll Call',
+    [VoteType.secretBallot]: 'Secret Ballot',
+    [VoteType.unanimousConsent]: 'Unanimous Consent',
+    [VoteType.placard]: 'Placard',
+  }[voteType];
+}
 
 export const yesNoOptions = {
   yes: 'Yes',

--- a/attendance-manager/src/utils/voting_utils.ts
+++ b/attendance-manager/src/utils/voting_utils.ts
@@ -1,10 +1,21 @@
 import { VotingEventWithRelations } from '@/types';
-import { VOTING_TYPES } from '@/utils/consts';
+import { votingTypes } from '@/utils/consts';
+
+const voteTypeLabels: Record<string, string> = {
+  [votingTypes.rollCall]: 'Roll Call',
+  [votingTypes.secretBallot]: 'Secret Ballot',
+  [votingTypes.unanimousConsent]: 'Unanimous Consent',
+  [votingTypes.placard]: 'Placard',
+};
+
+export function getVoteTypeLabel(voteType: string): string {
+  return voteTypeLabels[voteType] ?? voteType;
+}
 
 export function getVoteCounts(
   event: VotingEventWithRelations,
 ): Record<string, number> {
-  if (event.voteType === VOTING_TYPES.SECRET_BALLOT.key) {
+  if (event.voteType === votingTypes.secretBallot) {
     return event.resultCounts ?? {};
   }
   return (event.votingRecords ?? [])

--- a/attendance-manager/src/utils/voting_utils.ts
+++ b/attendance-manager/src/utils/voting_utils.ts
@@ -1,21 +1,10 @@
 import { VotingEventWithRelations } from '@/types';
-import { votingTypes } from '@/utils/consts';
-
-const voteTypeLabels: Record<string, string> = {
-  [votingTypes.rollCall]: 'Roll Call',
-  [votingTypes.secretBallot]: 'Secret Ballot',
-  [votingTypes.unanimousConsent]: 'Unanimous Consent',
-  [votingTypes.placard]: 'Placard',
-};
-
-export function getVoteTypeLabel(voteType: string): string {
-  return voteTypeLabels[voteType] ?? voteType;
-}
+import { VoteType } from '@/utils/consts';
 
 export function getVoteCounts(
   event: VotingEventWithRelations,
 ): Record<string, number> {
-  if (event.voteType === votingTypes.secretBallot) {
+  if (event.voteType === VoteType.secretBallot) {
     return event.resultCounts ?? {};
   }
   return (event.votingRecords ?? [])

--- a/attendance-manager/src/voting-record/__tests__/voting-record.test.ts
+++ b/attendance-manager/src/voting-record/__tests__/voting-record.test.ts
@@ -896,10 +896,7 @@ describe('PATCH /api/voting-record/[votingRecordId]', () => {
     await UsersService.deleteRole(patchRoleId);
   });
 
-  it('should update a voting record via PATCH route', async () => {
-    const { PATCH } = await import(
-      '../../app/api/voting-record/[votingRecordId]/route'
-    );
+  it('should update a voting record', async () => {
     const req = new Request(
       `http://localhost/api/voting-record/${patchRecordId}`,
       {
@@ -911,8 +908,8 @@ describe('PATCH /api/voting-record/[votingRecordId]', () => {
         }),
       },
     );
-    const response = await PATCH(req, {
-      params: Promise.resolve({ votingRecordId: patchRecordId }),
+    const response = await VotingRecordController.updateVotingRecord(req, {
+      votingRecordId: patchRecordId,
     });
     const data = await response.json();
 
@@ -928,9 +925,10 @@ describe('PATCH /api/voting-record/[votingRecordId]', () => {
         body: JSON.stringify({ result: 'YES' }),
       },
     );
-    const restoreRes = await PATCH(restoreReq, {
-      params: Promise.resolve({ votingRecordId: patchRecordId }),
-    });
+    const restoreRes = await VotingRecordController.updateVotingRecord(
+      restoreReq,
+      { votingRecordId: patchRecordId },
+    );
     expect(restoreRes.status).toBe(200);
   });
 });

--- a/attendance-manager/src/voting-record/voting-record.controller.ts
+++ b/attendance-manager/src/voting-record/voting-record.controller.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '../lib/prisma';
-import { VOTING_TYPES, YES_NO_OPTIONS } from '../utils/consts';
+import { votingTypes, yesNoOptions } from '../utils/consts';
 import { VotingRecordService } from './voting-record.service';
 
 const rollCallStyleResults = new Set<string>([
-  ...Object.values(YES_NO_OPTIONS),
+  ...Object.values(yesNoOptions),
   'YES',
   'NO',
   'ABSTAIN',
@@ -15,7 +15,7 @@ function isValidVotingRecordResult(
   options: string[],
   result: string,
 ): boolean {
-  if (voteType === VOTING_TYPES.ROLL_CALL.key) {
+  if (voteType === votingTypes.rollCall) {
     return rollCallStyleResults.has(result);
   }
   if (options.length > 0) {
@@ -38,7 +38,7 @@ export const VotingRecordController = {
     if (!votingEvent) {
       return NextResponse.json([]);
     }
-    if (votingEvent.voteType === VOTING_TYPES.SECRET_BALLOT.key) {
+    if (votingEvent.voteType === votingTypes.secretBallot) {
       return NextResponse.json(
         {
           error:
@@ -159,7 +159,7 @@ export const VotingRecordController = {
       );
     }
 
-    if (event.voteType === VOTING_TYPES.SECRET_BALLOT.key) {
+    if (event.voteType === votingTypes.secretBallot) {
       return NextResponse.json(
         {
           error: 'Voting records cannot be edited for secret ballot events',

--- a/attendance-manager/src/voting-record/voting-record.controller.ts
+++ b/attendance-manager/src/voting-record/voting-record.controller.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '../lib/prisma';
-import { votingTypes, yesNoOptions } from '../utils/consts';
+import { VoteType, yesNoOptions } from '../utils/consts';
 import { VotingRecordService } from './voting-record.service';
 
 const rollCallStyleResults = new Set<string>([
@@ -15,7 +15,7 @@ function isValidVotingRecordResult(
   options: string[],
   result: string,
 ): boolean {
-  if (voteType === votingTypes.rollCall) {
+  if (voteType === VoteType.rollCall) {
     return rollCallStyleResults.has(result);
   }
   if (options.length > 0) {
@@ -38,7 +38,7 @@ export const VotingRecordController = {
     if (!votingEvent) {
       return NextResponse.json([]);
     }
-    if (votingEvent.voteType === votingTypes.secretBallot) {
+    if (votingEvent.voteType === VoteType.secretBallot) {
       return NextResponse.json(
         {
           error:
@@ -159,7 +159,7 @@ export const VotingRecordController = {
       );
     }
 
-    if (event.voteType === votingTypes.secretBallot) {
+    if (event.voteType === VoteType.secretBallot) {
       return NextResponse.json(
         {
           error: 'Voting records cannot be edited for secret ballot events',

--- a/attendance-manager/src/voting/__tests__/voting.test.ts
+++ b/attendance-manager/src/voting/__tests__/voting.test.ts
@@ -6,7 +6,7 @@ import {
 import { VotingController } from '../voting.controller';
 import { prisma } from '../../lib/prisma';
 import { MeetingService } from '@/meeting/meeting.service';
-import { VOTING_TYPES } from '@/utils/consts';
+import { votingTypes } from '@/utils/consts';
 import * as apiAuth from '@/utils/api-auth';
 
 jest.setTimeout(20000);
@@ -132,7 +132,7 @@ describe('VotingService', () => {
   });
 
   it('should fetch all voting events', async () => {
-    const votingEvents = await VotingService.getAllVotingEvents({ isEboard: true });
+    const votingEvents = await VotingService.getAllVotingEvents();
     expect(Array.isArray(votingEvents)).toBe(true);
     expect(votingEvents.length).toBeGreaterThan(0);
   });
@@ -239,9 +239,11 @@ describe('VotingController', () => {
         voteType: 'YES_NO',
       });
 
-      const events = await VotingService.getAllVotingEvents({ isEboard: true });
-      expect(Array.isArray(events)).toBe(true);
-      expect(events.length).toBeGreaterThan(0);
+      const response = await VotingController.getAllVotingEvents();
+      expect(response).toBeDefined();
+      const responseData = await response.json();
+      expect(Array.isArray(responseData)).toBe(true);
+      expect(responseData.length).toBeGreaterThan(0);
       await VotingService.deleteVotingEvent(testVotingEvent.votingEventId);
     });
   });
@@ -555,17 +557,6 @@ describe('VotingController', () => {
 describe('GET /api/voting-event', () => {
   let routeTestMeetingId: string;
   let routeTestVotingEventId: string;
-  let requireAuthSpy: jest.SpyInstance;
-
-  beforeAll(() => {
-    requireAuthSpy = jest
-      .spyOn(apiAuth, 'requireAuth')
-      .mockResolvedValue({ user: { role: { roleType: 'EBOARD' } } as any, error: null });
-  });
-
-  afterAll(() => {
-    requireAuthSpy.mockRestore();
-  });
 
   beforeAll(async () => {
     // Create a test meeting
@@ -798,7 +789,7 @@ describe('Per-voter voting results include voter names (non-secret ballot)', () 
 
   // same enrichment as GET [id], but via getAllVotingEvents()
   it('getAllVotingEvents returns votingRecords with user first/last names for ROLL_CALL', async () => {
-    const events = await VotingService.getAllVotingEvents({ isEboard: true });
+    const events = await VotingService.getAllVotingEvents();
     const data = events.find(
       (e) => e != null && e.votingEventId === votingEventId,
     );
@@ -982,7 +973,7 @@ describe('Secret ballot results (aggregates only)', () => {
       data: {
         meetingId: testMeetingId,
         name: 'Budget approval (secret)',
-        voteType: VOTING_TYPES.SECRET_BALLOT.key,
+        voteType: votingTypes.secretBallot,
         notes: 'Motion notes for the secret ballot',
         options: ['Yes', 'No', 'Abstain', 'No Confidence'],
         deletedAt: new Date(),
@@ -1023,7 +1014,7 @@ describe('Secret ballot results (aggregates only)', () => {
     expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data.voteType).toBe(VOTING_TYPES.SECRET_BALLOT.key);
+    expect(data.voteType).toBe(votingTypes.secretBallot);
     expect(data.notes).toBe('Motion notes for the secret ballot');
     expect(data.resultCounts).toEqual({ Yes: 2, No: 1 });
     expect(data.votePassed).toBe(true);
@@ -1033,7 +1024,7 @@ describe('Secret ballot results (aggregates only)', () => {
   });
 
   it('getAllVotingEvents omits votingRecords for secret ballot with aggregates', async () => {
-    const events = await VotingService.getAllVotingEvents({ isEboard: true });
+    const events = await VotingService.getAllVotingEvents();
     const row = events.find(
       (e) => e != null && e.votingEventId === secretVotingEventId,
     );
@@ -1049,10 +1040,10 @@ describe('Secret ballot results (aggregates only)', () => {
     const { GET } =
       await import('../../app/api/voting-event/by-type/[voteType]/route');
     const req = new Request(
-      `http://localhost/api/voting-event/by-type/${VOTING_TYPES.SECRET_BALLOT.key}`,
+      `http://localhost/api/voting-event/by-type/${votingTypes.secretBallot}`,
     );
     const params = Promise.resolve({
-      voteType: VOTING_TYPES.SECRET_BALLOT.key,
+      voteType: votingTypes.secretBallot,
     });
     const response = await GET(req, { params });
     expect(response.status).toBe(200);
@@ -1237,7 +1228,7 @@ describe('POST /api/voting-event', () => {
     const requestBody = {
       meetingId: routeTestMeetingId,
       name: 'POST Secret Ballot Defaults',
-      voteType: VOTING_TYPES.SECRET_BALLOT.key,
+      voteType: votingTypes.secretBallot,
       options: ['Candidate 1', 'Candidate 2'],
       updatedBy: 'test-user',
     };
@@ -1268,7 +1259,7 @@ describe('POST /api/voting-event', () => {
     const requestBody = {
       meetingId: routeTestMeetingId,
       name: 'POST Route Invalid Options',
-      voteType: VOTING_TYPES.SECRET_BALLOT.key,
+      voteType: votingTypes.secretBallot,
       options: ['Candidate 1', 123],
       updatedBy: 'test-user',
     };

--- a/attendance-manager/src/voting/__tests__/voting.test.ts
+++ b/attendance-manager/src/voting/__tests__/voting.test.ts
@@ -132,7 +132,9 @@ describe('VotingService', () => {
   });
 
   it('should fetch all voting events', async () => {
-    const votingEvents = await VotingService.getAllVotingEvents();
+    const votingEvents = await VotingService.getAllVotingEvents({
+      isEboard: true,
+    });
     expect(Array.isArray(votingEvents)).toBe(true);
     expect(votingEvents.length).toBeGreaterThan(0);
   });
@@ -789,7 +791,7 @@ describe('Per-voter voting results include voter names (non-secret ballot)', () 
 
   // same enrichment as GET [id], but via getAllVotingEvents()
   it('getAllVotingEvents returns votingRecords with user first/last names for ROLL_CALL', async () => {
-    const events = await VotingService.getAllVotingEvents();
+    const events = await VotingService.getAllVotingEvents({ isEboard: true });
     const data = events.find(
       (e) => e != null && e.votingEventId === votingEventId,
     );
@@ -1024,7 +1026,7 @@ describe('Secret ballot results (aggregates only)', () => {
   });
 
   it('getAllVotingEvents omits votingRecords for secret ballot with aggregates', async () => {
-    const events = await VotingService.getAllVotingEvents();
+    const events = await VotingService.getAllVotingEvents({ isEboard: true });
     const row = events.find(
       (e) => e != null && e.votingEventId === secretVotingEventId,
     );

--- a/attendance-manager/src/voting/__tests__/voting.test.ts
+++ b/attendance-manager/src/voting/__tests__/voting.test.ts
@@ -6,7 +6,7 @@ import {
 import { VotingController } from '../voting.controller';
 import { prisma } from '../../lib/prisma';
 import { MeetingService } from '@/meeting/meeting.service';
-import { votingTypes } from '@/utils/consts';
+import { VoteType } from '@/utils/consts';
 import * as apiAuth from '@/utils/api-auth';
 
 jest.setTimeout(20000);
@@ -192,8 +192,13 @@ describe('VotingController', () => {
   let testMeetingId: string;
   let testMeeting2Id: string;
   let _testVotingEventId: string;
+  let requireAuthSpy: jest.SpyInstance;
 
   beforeAll(async () => {
+    requireAuthSpy = jest.spyOn(apiAuth, 'requireAuth').mockResolvedValue({
+      user: { role: { roleType: 'EBOARD' } } as any,
+      error: null,
+    });
     // Create test meetings
     const meeting = await prisma.meeting.create({
       data: {
@@ -221,6 +226,7 @@ describe('VotingController', () => {
   });
 
   afterAll(async () => {
+    requireAuthSpy.mockRestore();
     await prisma.votingEvent.deleteMany({
       where: {
         meetingId: {
@@ -559,8 +565,13 @@ describe('VotingController', () => {
 describe('GET /api/voting-event', () => {
   let routeTestMeetingId: string;
   let routeTestVotingEventId: string;
+  let requireAuthSpy: jest.SpyInstance;
 
   beforeAll(async () => {
+    requireAuthSpy = jest.spyOn(apiAuth, 'requireAuth').mockResolvedValue({
+      user: { role: { roleType: 'EBOARD' } } as any,
+      error: null,
+    });
     // Create a test meeting
     const meeting = await prisma.meeting.create({
       data: {
@@ -584,6 +595,7 @@ describe('GET /api/voting-event', () => {
   });
 
   afterAll(async () => {
+    requireAuthSpy.mockRestore();
     await VotingService.deleteVotingEvent(routeTestVotingEventId);
     await MeetingService.deleteMeeting(routeTestMeetingId);
   });
@@ -975,7 +987,7 @@ describe('Secret ballot results (aggregates only)', () => {
       data: {
         meetingId: testMeetingId,
         name: 'Budget approval (secret)',
-        voteType: votingTypes.secretBallot,
+        voteType: VoteType.secretBallot,
         notes: 'Motion notes for the secret ballot',
         options: ['Yes', 'No', 'Abstain', 'No Confidence'],
         deletedAt: new Date(),
@@ -1016,7 +1028,7 @@ describe('Secret ballot results (aggregates only)', () => {
     expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data.voteType).toBe(votingTypes.secretBallot);
+    expect(data.voteType).toBe(VoteType.secretBallot);
     expect(data.notes).toBe('Motion notes for the secret ballot');
     expect(data.resultCounts).toEqual({ Yes: 2, No: 1 });
     expect(data.votePassed).toBe(true);
@@ -1042,10 +1054,10 @@ describe('Secret ballot results (aggregates only)', () => {
     const { GET } =
       await import('../../app/api/voting-event/by-type/[voteType]/route');
     const req = new Request(
-      `http://localhost/api/voting-event/by-type/${votingTypes.secretBallot}`,
+      `http://localhost/api/voting-event/by-type/${VoteType.secretBallot}`,
     );
     const params = Promise.resolve({
-      voteType: votingTypes.secretBallot,
+      voteType: VoteType.secretBallot,
     });
     const response = await GET(req, { params });
     expect(response.status).toBe(200);
@@ -1230,7 +1242,7 @@ describe('POST /api/voting-event', () => {
     const requestBody = {
       meetingId: routeTestMeetingId,
       name: 'POST Secret Ballot Defaults',
-      voteType: votingTypes.secretBallot,
+      voteType: VoteType.secretBallot,
       options: ['Candidate 1', 'Candidate 2'],
       updatedBy: 'test-user',
     };
@@ -1261,7 +1273,7 @@ describe('POST /api/voting-event', () => {
     const requestBody = {
       meetingId: routeTestMeetingId,
       name: 'POST Route Invalid Options',
-      voteType: votingTypes.secretBallot,
+      voteType: VoteType.secretBallot,
       options: ['Candidate 1', 123],
       updatedBy: 'test-user',
     };

--- a/attendance-manager/src/voting/voting.controller.ts
+++ b/attendance-manager/src/voting/voting.controller.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { VotingService, formatVotingEventForApi } from './voting.service';
-import { VOTING_TYPES } from '@/utils/consts';
+import { votingTypes } from '@/utils/consts';
 import { requireAuth } from '@/utils/api-auth';
 
 const optionsSchema = z.array(z.string());
@@ -11,7 +11,7 @@ function normalizeCreateOptionsForSecretBallot(
   voteType: string,
   options: string[] | undefined,
 ): string[] | undefined {
-  if (voteType !== VOTING_TYPES.SECRET_BALLOT.key) return options;
+  if (voteType !== votingTypes.secretBallot) return options;
   const merged = [...(options ?? [])];
   for (const required of REQUIRED_SECRET_BALLOT_OPTIONS) {
     if (!merged.includes(required)) {
@@ -28,10 +28,7 @@ export const VotingController = {
   },
 
   async getAllVotingEvents() {
-    const { user, error } = await requireAuth();
-    if (error) return error;
-    const isEboard = user!.role.roleType === 'EBOARD';
-    const votingEvents = await VotingService.getAllVotingEvents({ isEboard });
+    const votingEvents = await VotingService.getAllVotingEvents();
     return NextResponse.json(votingEvents);
   },
 

--- a/attendance-manager/src/voting/voting.controller.ts
+++ b/attendance-manager/src/voting/voting.controller.ts
@@ -28,7 +28,10 @@ export const VotingController = {
   },
 
   async getAllVotingEvents() {
-    const votingEvents = await VotingService.getAllVotingEvents();
+    const { user, error } = await requireAuth();
+    if (error) return error;
+    const isEboard = user!.role.roleType === 'EBOARD';
+    const votingEvents = await VotingService.getAllVotingEvents({ isEboard });
     return NextResponse.json(votingEvents);
   },
 

--- a/attendance-manager/src/voting/voting.controller.ts
+++ b/attendance-manager/src/voting/voting.controller.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { VotingService, formatVotingEventForApi } from './voting.service';
-import { votingTypes } from '@/utils/consts';
+import { VoteType } from '@/utils/consts';
 import { requireAuth } from '@/utils/api-auth';
 
 const optionsSchema = z.array(z.string());
@@ -11,7 +11,7 @@ function normalizeCreateOptionsForSecretBallot(
   voteType: string,
   options: string[] | undefined,
 ): string[] | undefined {
-  if (voteType !== votingTypes.secretBallot) return options;
+  if (voteType !== VoteType.secretBallot) return options;
   const merged = [...(options ?? [])];
   for (const required of REQUIRED_SECRET_BALLOT_OPTIONS) {
     if (!merged.includes(required)) {

--- a/attendance-manager/src/voting/voting.service.ts
+++ b/attendance-manager/src/voting/voting.service.ts
@@ -1,7 +1,7 @@
 import { prisma } from '../lib/prisma';
-import { votingTypes } from '../utils/consts';
+import { VoteType } from '../utils/consts';
 
-const SECRET_BALLOT = votingTypes.secretBallot;
+const secretBallot = VoteType.secretBallot;
 
 export function computeVotePassedFromCounts(
   counts: Record<string, number>,
@@ -102,7 +102,7 @@ function redactSecretBallotForResults<
     secretBallotOutcomeKind?: SecretBallotOutcomeKind;
   },
 >(event: T): T {
-  if (event.voteType !== SECRET_BALLOT) return event;
+  if (event.voteType !== secretBallot) return event;
 
   const records = event.votingRecords || [];
   const hasRecords = records.some((r: any) => r && !r.deletedAt);
@@ -138,7 +138,7 @@ async function attachVoterNamesToVotingEvent<
   T extends { voteType: string; votingRecords?: any[] },
 >(event: T | null): Promise<T | null> {
   if (!event) return event;
-  if (event.voteType === SECRET_BALLOT) return event;
+  if (event.voteType === secretBallot) return event;
   if (!event.votingRecords || event.votingRecords.length === 0) return event;
 
   const userIds = Array.from(
@@ -216,7 +216,7 @@ export const VotingService = {
     // For ROLL_CALL: attach user names
     const withUsers = await attachVoterNamesToVotingEvent(event);
 
-    // Always format for API: aggregates for SECRET_BALLOT, etc.
+    // Always format for API: aggregates for secretBallot, etc.
     return formatVotingEventForApi(withUsers);
   },
 

--- a/attendance-manager/src/voting/voting.service.ts
+++ b/attendance-manager/src/voting/voting.service.ts
@@ -1,7 +1,7 @@
 import { prisma } from '../lib/prisma';
-import { VOTING_TYPES } from '../utils/consts';
+import { votingTypes } from '../utils/consts';
 
-const SECRET_BALLOT = VOTING_TYPES.SECRET_BALLOT.key;
+const SECRET_BALLOT = votingTypes.secretBallot;
 
 export function computeVotePassedFromCounts(
   counts: Record<string, number>,

--- a/attendance-manager/tailwind.config.js
+++ b/attendance-manager/tailwind.config.js
@@ -8,7 +8,25 @@ module.exports = {
     './contexts/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#C8102E',
+          dark: '#A8102E',
+        },
+        vote: {
+          yes: '#bbf7d0',
+          no: '#fecaca',
+          abstain: '#e5e7eb',
+          'no-confidence': '#fde68a',
+          f1: '#bfdbfe',
+          f2: '#ddd6fe',
+          f3: '#fbcfe8',
+          f4: '#99f6e4',
+          f5: '#fed7aa',
+        },
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary

- **Fix:** Admin's active vote card no longer disappears on page refresh — `useActiveVotingEvent` now polls `/api/voting-event/active` and returns all active events
- **Feature:** Stacked participation bar in the active vote card — each option occupies a width proportional to votes received vs eligible voters (PRESENT at the meeting), with inline labels showing `option · count · pct%`
- **Feature:** Per-vote participation summary — `Total Votes Cast: X/Y (Z%)` where Y is fetched from `/api/attendance/meeting/:id` counting PRESENT records
- **UX:** Multiple simultaneous active votes are each shown as separate cards with independent Close Vote buttons and error state
- **UX:** Newly created vote appears immediately (via `pendingEvent` merge) without waiting for the next poll
- **Refactor:** Extracted `VoteBreakdown` component out of the render IIFE; removed `useRef` in favour of an `eligibleCounts`-in-deps filter pattern; fixed `removeOption` to be index-based; removed dead `onEventCreated` prop

<img width="1866" height="960" alt="image" src="https://github.com/user-attachments/assets/0d96f866-25aa-480c-815e-3250a946b5e3" />

## Test plan

- [ ] Start a vote, refresh the page — Close Vote button should still appear
- [ ] Verify stacked bar renders with correct proportions as votes come in
- [ ] Verify participation count (X/Y) matches PRESENT attendance for that meeting
- [ ] Close a vote — results appear immediately in the Past Voting Results panel
- [ ] Start two votes simultaneously — both cards appear with independent close buttons
- [ ] Add and remove custom options in SECRET_BALLOT — confirm only the targeted option is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)