### PR TITLE
ATM-181 fix email prefetching with indirect link

### DIFF
--- a/attendance-manager/src/app/login/confirm/page.tsx
+++ b/attendance-manager/src/app/login/confirm/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
+import { CircleAlert, CircleCheck } from 'lucide-react';
+
+const CARD =
+  'max-w-md w-full bg-gray-800 rounded-2xl shadow-2xl p-8 border border-gray-700 text-center space-y-4';
+
+function ConfirmContent() {
+  const searchParams = useSearchParams();
+  const url = searchParams.get('url');
+
+  let isValidUrl = false;
+  let isRecovery = false;
+  try {
+    const parsed = new URL(url ?? '');
+    isValidUrl = parsed.hostname.endsWith('.supabase.co');
+    isRecovery = parsed.searchParams.get('type') === 'recovery';
+  } catch {
+    // invalid or missing URL — leave defaults
+  }
+
+  if (!isValidUrl) {
+    return (
+      <div className='min-h-screen bg-white flex items-center justify-center px-4'>
+        <div className={CARD}>
+          <CircleAlert className='h-12 w-12 text-red-400 mx-auto' />
+          <h2 className='text-xl font-bold text-white'>
+            Invalid confirmation link
+          </h2>
+          <p className='text-gray-400 text-sm'>
+            This link is missing or invalid. Please request a new one.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='min-h-screen bg-white flex items-center justify-center px-4'>
+      <div className={CARD}>
+        <CircleCheck className='h-12 w-12 text-green-400 mx-auto' />
+        <h2 className='text-3xl font-bold text-white'>
+          {isRecovery ? 'Reset Your Password' : 'Confirm Your Email'}
+        </h2>
+        <p className='text-gray-300 text-sm'>
+          {isRecovery
+            ? 'Your password reset link is ready.'
+            : 'Your verification link is ready.'}{' '}
+          Press the button below to proceed — do not share this page with
+          anyone.
+        </p>
+        <button
+          onClick={() => {
+            window.location.href = url!;
+          }}
+          className='w-full py-3 px-4 border border-transparent text-sm font-semibold rounded-xl text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-all duration-200 shadow-lg hover:shadow-xl'
+        >
+          {isRecovery ? 'Reset Password' : 'Confirm Email'}
+        </button>
+        <p className='text-sm text-gray-500'>
+          © 2026 Northeastern University Student Government Association. All
+          rights reserved.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function ConfirmPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ConfirmContent />
+    </Suspense>
+  );
+}

--- a/attendance-manager/src/app/login/confirm/page.tsx
+++ b/attendance-manager/src/app/login/confirm/page.tsx
@@ -4,9 +4,6 @@ import { useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 import { CircleAlert, CircleCheck } from 'lucide-react';
 
-const CARD =
-  'max-w-md w-full bg-gray-800 rounded-2xl shadow-2xl p-8 border border-gray-700 text-center space-y-4';
-
 function ConfirmContent() {
   const searchParams = useSearchParams();
   const url = searchParams.get('url');
@@ -21,44 +18,42 @@ function ConfirmContent() {
     // invalid or missing URL — leave defaults
   }
 
-  if (!isValidUrl) {
-    return (
-      <div className='min-h-screen bg-white flex items-center justify-center px-4'>
-        <div className={CARD}>
-          <CircleAlert className='h-12 w-12 text-red-400 mx-auto' />
-          <h2 className='text-xl font-bold text-white'>
-            Invalid confirmation link
-          </h2>
-          <p className='text-gray-400 text-sm'>
-            This link is missing or invalid. Please request a new one.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className='min-h-screen bg-white flex items-center justify-center px-4'>
-      <div className={CARD}>
-        <CircleCheck className='h-12 w-12 text-green-400 mx-auto' />
-        <h2 className='text-3xl font-bold text-white'>
-          {isRecovery ? 'Reset Your Password' : 'Confirm Your Email'}
-        </h2>
-        <p className='text-gray-300 text-sm'>
-          {isRecovery
-            ? 'Your password reset link is ready.'
-            : 'Your verification link is ready.'}{' '}
-          Press the button below to proceed — do not share this page with
-          anyone.
-        </p>
-        <button
-          onClick={() => {
-            window.location.href = url!;
-          }}
-          className='w-full py-3 px-4 border border-transparent text-sm font-semibold rounded-xl text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-all duration-200 shadow-lg hover:shadow-xl'
-        >
-          {isRecovery ? 'Reset Password' : 'Confirm Email'}
-        </button>
+      <div className='max-w-md w-full bg-gray-800 rounded-2xl shadow-2xl p-8 border border-gray-700 text-center space-y-4'>
+        {isValidUrl ? (
+          <>
+            <CircleCheck className='h-12 w-12 text-green-400 mx-auto' />
+            <h2 className='text-3xl font-bold text-white'>
+              {isRecovery ? 'Reset Your Password' : 'Confirm Your Email'}
+            </h2>
+            <p className='text-gray-300 text-sm'>
+              {isRecovery
+                ? 'Your password reset link is ready.'
+                : 'Your verification link is ready.'}{' '}
+              Press the button below to proceed — do not share this page with
+              anyone.
+            </p>
+            <button
+              onClick={() => {
+                window.location.href = url!;
+              }}
+              className='w-full py-3 px-4 border border-transparent text-sm font-semibold rounded-xl text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-all duration-200 shadow-lg hover:shadow-xl'
+            >
+              {isRecovery ? 'Reset Password' : 'Confirm Email'}
+            </button>
+          </>
+        ) : (
+          <>
+            <CircleAlert className='h-12 w-12 text-red-400 mx-auto' />
+            <h2 className='text-xl font-bold text-white'>
+              Invalid confirmation link
+            </h2>
+            <p className='text-gray-400 text-sm'>
+              This link is missing or invalid. Please request a new one.
+            </p>
+          </>
+        )}
         <p className='text-sm text-gray-500'>
           © 2026 Northeastern University Student Government Association. All
           rights reserved.

--- a/attendance-manager/src/app/login/confirm/page.tsx
+++ b/attendance-manager/src/app/login/confirm/page.tsx
@@ -34,14 +34,12 @@ function ConfirmContent() {
               Press the button below to proceed — do not share this page with
               anyone.
             </p>
-            <button
-              onClick={() => {
-                window.location.href = url!;
-              }}
-              className='w-full py-3 px-4 border border-transparent text-sm font-semibold rounded-xl text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-all duration-200 shadow-lg hover:shadow-xl'
+            <a
+              href={url ?? ''}
+              className='block w-full py-3 px-4 border border-transparent text-sm font-semibold rounded-xl text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-all duration-200 shadow-lg hover:shadow-xl'
             >
               {isRecovery ? 'Reset Password' : 'Confirm Email'}
-            </button>
+            </a>
           </>
         ) : (
           <>


### PR DESCRIPTION
## Summary
- Adds `/login/confirm` intermediate page between the email link and the actual Supabase verification URL
- Email scanners (e.g. Microsoft Defender Safe Links) prefetch `/login/confirm` but cannot consume the token — only the user's button click does
- URL is validated by checking the hostname ends with `.supabase.co` to prevent open redirect

## Required dashboard change
After merging, update both Supabase email templates (Confirm signup, Reset password) in the Supabase dashboard:

Change `{{ .ConfirmationURL }}` links to:
```
{{ .SiteURL }}/login/confirm?url={{ .ConfirmationURL }}
```

## Test plan
- [ ] Sign up with a new account and click the confirmation link — should land on `/login/confirm`, then confirm to `/login`
- [ ] Request a password reset and click the link — should land on `/login/confirm`, then confirm to `/login?mode=reset`
- [ ] Verify that hitting `/login/confirm` without a `url` param shows the error state
- [ ] Verify that a non-Supabase URL in the `url` param shows the error state
<img width="1866" height="960" alt="image" src="https://github.com/user-attachments/assets/33d6ef17-88f4-4906-a8dd-e85f933e005e" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)