### PR TITLE
ATM-183 remove PKCE flow from Supabase auth client

### DIFF
--- a/attendance-manager/src/lib/supabase.ts
+++ b/attendance-manager/src/lib/supabase.ts
@@ -6,7 +6,6 @@ export const createClient = () => {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       auth: {
-        flowType: 'pkce',
         persistSession: true,
         autoRefreshToken: true,
         detectSessionInUrl: true,


### PR DESCRIPTION
## Summary

- Removes `flowType: 'pkce'` from the Supabase browser client config
- Switches to implicit flow, which returns tokens in the URL hash and is picked up by `detectSessionInUrl: true`
- Fixes "auth session missing" error after clicking a password reset link — PKCE requires a server-side `/auth/callback` code exchange that was never implemented

## Test plan

- [ ] Request a password reset email
- [ ] Click the link in the email → lands on `/login/confirm`
- [ ] Click "Reset Password" → redirected to the reset form
- [ ] Enter a new password → succeeds without "auth session missing" error
- [ ] Sign up as a new user → confirmation email link still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)